### PR TITLE
WP1/2 Complete address and contract

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -195,6 +195,7 @@ public:
     //! block header
     int nVersion;
     uint256 hashMerkleRoot;
+    uint256 hashContract;
     unsigned int nTime;
     CProof proof;
 
@@ -222,6 +223,7 @@ public:
 
         nVersion       = 0;
         hashMerkleRoot = uint256();
+        hashContract   = uint256();
         nTime          = 0;
         proof.SetNull();
     }
@@ -237,6 +239,7 @@ public:
 
         nVersion       = block.nVersion;
         hashMerkleRoot = block.hashMerkleRoot;
+        hashContract   = block.hashContract;
         nTime          = block.nTime;
         nHeight        = block.nHeight;
         proof          = block.proof;
@@ -267,6 +270,7 @@ public:
         if (pprev)
             block.hashPrevBlock = pprev->GetBlockHash();
         block.hashMerkleRoot = hashMerkleRoot;
+        block.hashContract   = hashContract;
         block.nTime          = nTime;
         block.nHeight        = nHeight;
         block.proof          = proof;
@@ -383,6 +387,7 @@ public:
         READWRITE(this->nVersion);
         READWRITE(hashPrev);
         READWRITE(hashMerkleRoot);
+        READWRITE(hashContract);
         READWRITE(nTime);
         READWRITE(proof);
     }
@@ -393,6 +398,7 @@ public:
         block.nVersion        = nVersion;
         block.hashPrevBlock   = hashPrev;
         block.hashMerkleRoot  = hashMerkleRoot;
+        block.hashContract    = hashContract;
         block.nTime           = nTime;
         block.proof           = proof;
         block.nHeight         = nHeight;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -58,6 +58,7 @@ static CBlock CreateGenesisBlock(const Consensus::Params& params, const std::str
     genesis.vtx.push_back(MakeTransactionRef(std::move(txNew)));
     genesis.hashPrevBlock.SetNull();
     genesis.hashMerkleRoot = BlockMerkleRoot(genesis);
+    genesis.hashContract = GetContractHash();
     return genesis;
 }
 
@@ -195,6 +196,7 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,235);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,75);
         base58Prefixes[BLINDED_ADDRESS]= std::vector<unsigned char>(1,4);
+        base58Prefixes[EXTENDED_ADDRESS]= std::vector<unsigned char>(1,5);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container<std::vector<unsigned char> >();
@@ -220,6 +222,7 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,0);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);
         base58Prefixes[BLINDED_ADDRESS]= std::vector<unsigned char>(1,11);
+        base58Prefixes[EXTENDED_ADDRESS]= std::vector<unsigned char>(1,12);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,128);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x88)(0xB2)(0x1E).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x88)(0xAD)(0xE4).convert_to_container<std::vector<unsigned char> >();
@@ -258,4 +261,4 @@ void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_
 {
     globalChainParams->UpdateBIP9Parameters(d, nStartTime, nTimeout);
 }
- 
+

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -51,6 +51,7 @@ public:
         PUBKEY_ADDRESS,
         SCRIPT_ADDRESS,
         BLINDED_ADDRESS,
+        EXTENDED_ADDRESS,
         SECRET_KEY,
         EXT_PUBLIC_KEY,
         EXT_SECRET_KEY,

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -640,4 +640,5 @@ void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned
 
     pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+    pblock->hashContract = GetContractHash();
 }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -61,6 +61,7 @@ public:
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;
+    uint256 hashContract;
     uint32_t nTime;
     uint32_t nHeight;
     CProof proof;
@@ -77,6 +78,7 @@ public:
         READWRITE(this->nVersion);
         READWRITE(hashPrevBlock);
         READWRITE(hashMerkleRoot);
+        READWRITE(hashContract);
         READWRITE(nTime);
         READWRITE(nHeight);
         READWRITE(proof);
@@ -87,6 +89,7 @@ public:
         nVersion = 0;
         hashPrevBlock.SetNull();
         hashMerkleRoot.SetNull();
+        hashContract.SetNull();
         nTime = 0;
         nHeight = 0;
         proof.SetNull();
@@ -147,6 +150,7 @@ public:
         block.nVersion       = nVersion;
         block.hashPrevBlock  = hashPrevBlock;
         block.hashMerkleRoot = hashMerkleRoot;
+        block.hashContract   = hashContract;
         block.nTime          = nTime;
         block.nHeight        = nHeight;
         block.proof          = proof;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -77,7 +77,7 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("bits", GetChallengeStr(blockindex->GetBlockHeader())));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
-
+    result.push_back(Pair("contracthash", blockindex->hashContract.GetHex()));
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
     CBlockIndex *pnext = chainActive.Next(blockindex);
@@ -121,7 +121,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("bits", GetChallengeStr(block)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
-
+    result.push_back(Pair("contracthash", blockindex->hashContract.GetHex()));
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
     CBlockIndex *pnext = chainActive.Next(blockindex);
@@ -1192,7 +1192,7 @@ UniValue getchaintips(const JSONRPCRequest& request)
     LOCK(cs_main);
 
     /*
-     * Idea:  the set of chain tips is chainActive.tip, plus orphan blocks which do not have another orphan building off of them. 
+     * Idea:  the set of chain tips is chainActive.tip, plus orphan blocks which do not have another orphan building off of them.
      * Algorithm:
      *  - Make one pass through mapBlockIndex, picking out the orphan blocks, and also storing a set of the orphan block's pprev pointers.
      *  - Iterate through the orphan blocks. If the block isn't pointed to by another orphan, it is a chain tip.

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -216,7 +216,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
         if (address.IsBlinded()) {
             CPubKey key = address.GetBlindingKey();
             ret.push_back(Pair("confidential_key", HexStr(key.begin(), key.end())));
-            ret.push_back(Pair("unconfidential", address.GetUnblinded().ToString()));
+            ret.push_back(Pair("unconfidential", CBitcoinAddress(dest).ToString()));
         } else {
             ret.push_back(Pair("confidential_key", ""));
             ret.push_back(Pair("unconfidential", currentAddress));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -28,7 +28,7 @@ static const char DB_REINDEX_FLAG = 'R';
 static const char DB_LAST_BLOCK = 'l';
 
 
-CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, true) 
+CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, true)
 {
 }
 
@@ -213,6 +213,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
                 pindexNew->nUndoPos       = diskindex.nUndoPos;
                 pindexNew->nVersion       = diskindex.nVersion;
                 pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
+                pindexNew->hashContract   = diskindex.hashContract;
                 pindexNew->nTime          = diskindex.nTime;
                 pindexNew->proof          = diskindex.proof;
                 pindexNew->nStatus        = diskindex.nStatus;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8,7 +8,7 @@
 #endif
 
 #include "util.h"
-
+#include "hash.h"
 #include "chainparamsbase.h"
 #include "random.h"
 #include "serialize.h"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -863,6 +863,16 @@ std::string GetContractFile()
     return contract;
 }
 
+uint256 GetContractHash()
+{
+    const std::string contractFile = GetContractFile();
+    const std::string contract = contractFile.empty() ?
+      "These are the terms and conditions for using the CBT network." : contractFile;
+
+    std::vector<unsigned char> terms(contract.begin(), contract.end());
+    return Hash(terms.begin(), terms.end());
+}
+
 void RenameThread(const char* name)
 {
 #if defined(PR_SET_NAME)

--- a/src/util.h
+++ b/src/util.h
@@ -17,6 +17,7 @@
 #include "compat.h"
 #include "tinyformat.h"
 #include "utiltime.h"
+#include "uint256.h"
 
 #include <atomic>
 #include <exception>

--- a/src/util.h
+++ b/src/util.h
@@ -128,7 +128,7 @@ void OpenAuditLog();
 void ShrinkDebugFile();
 void runCommand(const std::string& strCommand);
 std::string GetContractFile();
-
+uint256 GetContractHash();
 
 inline bool IsSwitchChar(char c)
 {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -200,12 +200,7 @@ UniValue getnewaddress(const JSONRPCRequest& request)
 
     pwalletMain->SetAddressBook(keyID, strAccount, "receive");
 
-    CKeyMetadata meta = pwalletMain->mapKeyMetadata[keyID];
-    std::vector<unsigned char> extendedKeyId;
-    extendedKeyId.insert(extendedKeyId.end(), keyID.begin(), keyID.end());
-    extendedKeyId.insert(extendedKeyId.end(), meta.hdPubKeyHash.begin(), meta.hdPubKeyHash.end());
-
-    return CBitcoinAddress(extendedKeyId).AddBlindingKey(pwalletMain->GetBlindingPubKey(GetScriptForDestination(CTxDestination(keyID)))).ToString();
+    return CBitcoinAddress(keyID).AddBlindingKey(pwalletMain->GetBlindingPubKey(GetScriptForDestination(CTxDestination(keyID)))).ToString();
 }
 
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -112,7 +112,7 @@ CPubKey CWallet::GenerateNewKey()
     if (fCompressed)
         SetMinVersion(FEATURE_COMPRPUBKEY);
 
-    uint256 contract = GetContract(); // for BIP-175
+    uint256 contract = GetContractHash(); // for BIP-175
 
     CPubKey pubKeyTest = secret.GetPubKey();
     metadata.hdPubKeyHash = pubKeyTest.GetID();
@@ -3694,17 +3694,6 @@ bool CWallet::GetKeyFromPool(CPubKey& result)
         result = keypool.vchPubKey;
     }
     return true;
-}
-
-uint256 CWallet::GetContract()
-{
-    const std::string contractFile = GetContractFile();
-    const std::string contract = contractFile.empty() ?
-      "These are the terms and conditions for using the CBT network." : contractFile;
-
-    std::vector<unsigned char> terms(contract.begin(), contract.end());
-
-    return Hash(terms.begin(), terms.end());
 }
 
 int64_t CWallet::GetOldestKeyPoolTime()


### PR DESCRIPTION
Add unique prefix to address (random for now). Extended address generated so that payee can extract the appropriate information for the transaction, while the pay to address in the transaction is the encoding of tweaked pub key.

Add contract hash to block header and the genesis block.