### PR TITLE
Demo - Customize Ocean

### DIFF
--- a/qa/rpc-tests/confidential_transactions.py
+++ b/qa/rpc-tests/confidential_transactions.py
@@ -26,16 +26,16 @@ class CTTest (BitcoinTestFramework):
         self.nodes[0].generate(101)
         self.sync_all()
         #Running balances
-        node0 = self.nodes[0].getbalance()["bitcoin"]
+        node0 = self.nodes[0].getbalance()["CBT"]
         node1 = 0
         node2 = 0
 
         self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), node0, "", "", True)
         self.nodes[0].generate(101)
         self.sync_all()
-        assert_equal(self.nodes[0].getbalance()["bitcoin"], node0)
-        assert_equal(self.nodes[1].getbalance("", 1, False, "bitcoin"), node1)
-        assert_equal(self.nodes[2].getbalance("", 1, False, "bitcoin"), node2)
+        assert_equal(self.nodes[0].getbalance()["CBT"], node0)
+        assert_equal(self.nodes[1].getbalance("", 1, False, "CBT"), node1)
+        assert_equal(self.nodes[2].getbalance("", 1, False, "CBT"), node2)
 
         # Send 3 BTC from 0 to a new unconfidential address of 2 with
         # the sendtoaddress call
@@ -49,9 +49,9 @@ class CTTest (BitcoinTestFramework):
         node0 = node0 - value0
         node2 = node2 + value0
 
-        assert_equal(self.nodes[0].getbalance()["bitcoin"], node0)
-        assert_equal(self.nodes[1].getbalance("", 1, False, "bitcoin"), node1)
-        assert_equal(self.nodes[2].getbalance()["bitcoin"], node2)
+        assert_equal(self.nodes[0].getbalance()["CBT"], node0)
+        assert_equal(self.nodes[1].getbalance("", 1, False, "CBT"), node1)
+        assert_equal(self.nodes[2].getbalance()["CBT"], node2)
 
         # Send 5 BTC from 0 to a new address of 2 with the sendtoaddress call
         address = self.nodes[2].getnewaddress()
@@ -64,9 +64,9 @@ class CTTest (BitcoinTestFramework):
         node0 = node0 - value1
         node2 = node2 + value1
 
-        assert_equal(self.nodes[0].getbalance()["bitcoin"], node0)
-        assert_equal(self.nodes[1].getbalance("", 1, False, "bitcoin"), node1)
-        assert_equal(self.nodes[2].getbalance()["bitcoin"], node2)
+        assert_equal(self.nodes[0].getbalance()["CBT"], node0)
+        assert_equal(self.nodes[1].getbalance("", 1, False, "CBT"), node1)
+        assert_equal(self.nodes[2].getbalance()["CBT"], node2)
 
         # Send 7 BTC from 0 to the unconfidential address of 2 and 11 BTC to the
         # confidential address using the raw transaction interface
@@ -74,7 +74,7 @@ class CTTest (BitcoinTestFramework):
         value2 = 7
         value3 = 11
         value23 = value2 + value3
-        unspent = self.nodes[0].listunspent(1, 9999999, [], True, "bitcoin")
+        unspent = self.nodes[0].listunspent(1, 9999999, [], True, "CBT")
         unspent = [i for i in unspent if i['amount'] > value23]
         assert_equal(len(unspent), 1)
         fee = Decimal('0.0001')
@@ -92,12 +92,12 @@ class CTTest (BitcoinTestFramework):
         node0 -= (value2 + value3)
         node2 += value2 + value3
 
-        assert_equal(self.nodes[0].getbalance()["bitcoin"], node0)
-        assert_equal(self.nodes[1].getbalance("", 1, False, "bitcoin"), node1)
-        assert_equal(self.nodes[2].getbalance()["bitcoin"], node2)
+        assert_equal(self.nodes[0].getbalance()["CBT"], node0)
+        assert_equal(self.nodes[1].getbalance("", 1, False, "CBT"), node1)
+        assert_equal(self.nodes[2].getbalance()["CBT"], node2)
 
         # Check 2's listreceivedbyaddress
-        received_by_address = self.nodes[2].listreceivedbyaddress(0, False, False, "bitcoin")
+        received_by_address = self.nodes[2].listreceivedbyaddress(0, False, False, "CBT")
         validate_by_address = [(unconfidential_address2, value1 + value3), (unconfidential_address, value0 + value2)]
         assert_equal(sorted([(ele['address'], ele['amount']) for ele in received_by_address], key=lambda t: t[0]),
                 sorted(validate_by_address, key = lambda t: t[0]))
@@ -108,16 +108,16 @@ class CTTest (BitcoinTestFramework):
         received_by_address = self.nodes[1].listreceivedbyaddress(1, False, True)
         #Node sees nothing unless it understands the values
         assert_equal(len(received_by_address), 0)
-        assert_equal(len(self.nodes[1].listunspent(1, 9999999, [], True, "bitcoin")), 0)
+        assert_equal(len(self.nodes[1].listunspent(1, 9999999, [], True, "CBT")), 0)
 
         # Import the blinding key
         blindingkey = self.nodes[2].dumpblindingkey(address)
         self.nodes[1].importblindingkey(address, blindingkey)
         # Check the auditor's gettransaction and listreceivedbyaddress
         # Needs rescan to update wallet txns
-        assert_equal(self.nodes[1].gettransaction(confidential_tx_id, True)['amount']["bitcoin"], value1)
-        assert_equal(self.nodes[1].gettransaction(raw_tx_id, True)['amount']["bitcoin"], value3)
-        list_unspent = self.nodes[1].listunspent(1, 9999999, [], True, "bitcoin")
+        assert_equal(self.nodes[1].gettransaction(confidential_tx_id, True)['amount']["CBT"], value1)
+        assert_equal(self.nodes[1].gettransaction(raw_tx_id, True)['amount']["CBT"], value3)
+        list_unspent = self.nodes[1].listunspent(1, 9999999, [], True, "CBT")
         assert_equal(list_unspent[0]['amount']+list_unspent[1]['amount'], value1+value3)
         received_by_address = self.nodes[1].listreceivedbyaddress(1, False, True)
         assert_equal(len(received_by_address), 1)
@@ -127,7 +127,7 @@ class CTTest (BitcoinTestFramework):
         # Spending a single confidential output and sending it to a
         # unconfidential output is not possible with CT. Test the
         # correct behavior of blindrawtransaction.
-        unspent = self.nodes[0].listunspent(1, 9999999, [], True, "bitcoin")
+        unspent = self.nodes[0].listunspent(1, 9999999, [], True, "CBT")
         unspent = [i for i in unspent if i['amount'] > value23]
         assert_equal(len(unspent), 1)
         tx = self.nodes[0].createrawtransaction([{"txid": unspent[0]["txid"],
@@ -168,9 +168,9 @@ class CTTest (BitcoinTestFramework):
 
         node0 -= value4
         node2 += value4
-        assert_equal(self.nodes[0].getbalance()["bitcoin"], node0)
-        assert_equal(self.nodes[1].getbalance("", 1, False, "bitcoin"), node1)
-        assert_equal(self.nodes[2].getbalance()["bitcoin"], node2)
+        assert_equal(self.nodes[0].getbalance()["CBT"], node0)
+        assert_equal(self.nodes[1].getbalance("", 1, False, "CBT"), node1)
+        assert_equal(self.nodes[2].getbalance()["CBT"], node2)
 
         # Testing wallet's ability to deblind its own outputs
         addr = self.nodes[0].getnewaddress()
@@ -212,7 +212,7 @@ class CTTest (BitcoinTestFramework):
         print("Assets tests...")
 
         # Bitcoin is the first issuance
-        assert_equal(self.nodes[0].listissuances()[0]["assetlabel"], "bitcoin")
+        assert_equal(self.nodes[0].listissuances()[0]["assetlabel"], "CBT")
         assert_equal(len(self.nodes[0].listissuances()), 1)
 
         # Unblinded issuance of asset
@@ -234,8 +234,8 @@ class CTTest (BitcoinTestFramework):
 
         # Assets balance checking, note that accounts are completely ignored because
         # balance queries with accounts are horrifically broken upstream
-        assert_equal(self.nodes[0].getbalance("*", 0, False, "bitcoin"), self.nodes[0].getbalance("accountsareignored", 0, False, "bitcoin"))
-        assert_equal(self.nodes[0].getwalletinfo()['balance']['bitcoin'], self.nodes[0].getbalance("accountsareignored", 0, False, "bitcoin"))
+        assert_equal(self.nodes[0].getbalance("*", 0, False, "CBT"), self.nodes[0].getbalance("accountsareignored", 0, False, "CBT"))
+        assert_equal(self.nodes[0].getwalletinfo()['balance']['bitcoin'], self.nodes[0].getbalance("accountsareignored", 0, False, "CBT"))
 
         # Send some bitcoin and other assets over as well to fund wallet
         addr = self.nodes[2].getnewaddress()
@@ -248,7 +248,7 @@ class CTTest (BitcoinTestFramework):
         assert_equal(self.nodes[0].getbalance("doesntmatter", 0, False, test_asset), 1)
         assert_equal(self.nodes[2].getunconfirmedbalance(test_asset), Decimal(1))
 
-        b_utxos = self.nodes[2].listunspent(0, 0, [], True, "bitcoin")
+        b_utxos = self.nodes[2].listunspent(0, 0, [], True, "CBT")
         t_utxos = self.nodes[2].listunspent(0, 0, [], True, test_asset)
 
         assert_equal(len(self.nodes[2].listunspent(0, 0, [])), len(b_utxos)+len(t_utxos))
@@ -473,11 +473,11 @@ class CTTest (BitcoinTestFramework):
         # due to the fact that the output value is 0-value and input pedersen commitments
         # self-balance. This is rare corner case, but ok.
         unblinded = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())["unconfidential"]
-        self.nodes[0].sendtoaddress(unblinded, self.nodes[0].getbalance()["bitcoin"], "", "", True)
+        self.nodes[0].sendtoaddress(unblinded, self.nodes[0].getbalance()["CBT"], "", "", True)
         # Make tx with blinded destination and change outputs only
-        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[0].getbalance()["bitcoin"]/2)
+        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[0].getbalance()["CBT"]/2)
         # Send back again, this transaction should have 3 outputs, all unblinded
-        txid = self.nodes[0].sendtoaddress(unblinded, self.nodes[0].getbalance()["bitcoin"], "", "", True)
+        txid = self.nodes[0].sendtoaddress(unblinded, self.nodes[0].getbalance()["CBT"], "", "", True)
         outputs = self.nodes[0].getrawtransaction(txid, 1)["vout"]
         assert_equal(len(outputs), 3)
         assert("value" in outputs[0] and "value" in outputs[1] and "value" in outputs[2])

--- a/qa/rpc-tests/listsinceblock.py
+++ b/qa/rpc-tests/listsinceblock.py
@@ -50,7 +50,7 @@ class ListSinceBlockTest (BitcoinTestFramework):
 
         assert_equal(self.nodes[0].getbalance(), {})
         assert_equal(self.nodes[1].getbalance(), {})
-        assert_equal(self.nodes[2].getbalance()["bitcoin"], 21000000)
+        assert_equal(self.nodes[2].getbalance()["CBT"], 21000000)
         assert_equal(self.nodes[3].getbalance(), {})
 
         # Split network into two

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -85,18 +85,18 @@ class RawTransactionsTest(BitcoinTestFramework):
         mSigObjValid = self.nodes[2].validateaddress(mSigObj)
 
         #use balance deltas instead of absolute values
-        bal = self.nodes[2].getbalance()["bitcoin"]
+        bal = self.nodes[2].getbalance()["CBT"]
 
         # send 1.2 BTC to msig adr
         txId = self.nodes[0].sendtoaddress(mSigObj, 1.2)
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
-        assert_equal(self.nodes[2].getbalance()["bitcoin"], bal+Decimal('1.20000000')) #node2 has both keys of the 2of2 ms addr., tx should affect the balance
+        assert_equal(self.nodes[2].getbalance()["CBT"], bal+Decimal('1.20000000')) #node2 has both keys of the 2of2 ms addr., tx should affect the balance
 
 
         # 2of3 test from different nodes
-        bal = self.nodes[2].getbalance()["bitcoin"]
+        bal = self.nodes[2].getbalance()["CBT"]
         addr1 = self.nodes[1].getnewaddress()
         addr2 = self.nodes[2].getnewaddress()
         addr3 = self.nodes[2].getnewaddress()
@@ -118,7 +118,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         #THIS IS A INCOMPLETE FEATURE
         #NODE2 HAS TWO OF THREE KEY AND THE FUNDS SHOULD BE SPENDABLE AND COUNT AT BALANCE CALCULATION
-        assert_equal(self.nodes[2].getbalance()["bitcoin"], bal) #for now, assume the funds of a 2of3 multisig tx are not marked as spendable
+        assert_equal(self.nodes[2].getbalance()["CBT"], bal) #for now, assume the funds of a 2of3 multisig tx are not marked as spendable
 
         txDetails = self.nodes[0].gettransaction(txId, True)
         rawTx = self.nodes[0].decoderawtransaction(txDetails['hex'])

--- a/qa/rpc-tests/receivedby.py
+++ b/qa/rpc-tests/receivedby.py
@@ -56,11 +56,11 @@ class ReceivedByTest(BitcoinTestFramework):
         self.sync_all()
         assert_array_result(self.nodes[1].listreceivedbyaddress(),
                            {"address":unblinded},
-                           {"address":unblinded, "account":"", "amount":{"bitcoin":Decimal("0.1")}, "confirmations":10, "txids":[txid,]})
+                           {"address":unblinded, "account":"", "amount":{"CBT":Decimal("0.1")}, "confirmations":10, "txids":[txid,]})
         #With min confidence < 10
         assert_array_result(self.nodes[1].listreceivedbyaddress(5),
                            {"address":unblinded},
-                           {"address":unblinded, "account":"", "amount":{"bitcoin":Decimal("0.1")}, "confirmations":10, "txids":[txid,]})
+                           {"address":unblinded, "account":"", "amount":{"CBT":Decimal("0.1")}, "confirmations":10, "txids":[txid,]})
         #With min confidence > 10, should not find Tx
         assert_array_result(self.nodes[1].listreceivedbyaddress(11),{"blindedaddress":addr},{ },True)
 
@@ -81,19 +81,19 @@ class ReceivedByTest(BitcoinTestFramework):
         self.sync_all()
 
         #Check balance is 0 because of 0 confirmations
-        balance = self.nodes[1].getreceivedbyaddress(unblinded, 1, "bitcoin")
+        balance = self.nodes[1].getreceivedbyaddress(unblinded, 1, "CBT")
         if balance != Decimal("0.0"):
             raise AssertionError("Wrong balance returned by getreceivedbyaddress, %0.2f"%(balance))
 
         #Check balance is 0.1
-        balance = self.nodes[1].getreceivedbyaddress(unblinded,0, "bitcoin")
+        balance = self.nodes[1].getreceivedbyaddress(unblinded,0, "CBT")
         if balance != Decimal("0.1"):
             raise AssertionError("Wrong balance returned by getreceivedbyaddress, %0.2f"%(balance))
 
         #Bury Tx under 10 block so it will be returned by the default getreceivedbyaddress
         self.nodes[1].generate(10)
         self.sync_all()
-        balance = self.nodes[1].getreceivedbyaddress(unblinded, 1, "bitcoin")
+        balance = self.nodes[1].getreceivedbyaddress(unblinded, 1, "CBT")
         if balance != Decimal("0.1"):
             raise AssertionError("Wrong balance returned by getreceivedbyaddress, %0.2f"%(balance))
 
@@ -106,7 +106,7 @@ class ReceivedByTest(BitcoinTestFramework):
         received_by_account_json = get_sub_array_from_array(self.nodes[1].listreceivedbyaccount(),{"account":account})
         if len(received_by_account_json) == 0:
             raise AssertionError("No accounts found in node")
-        balance_by_account = self.nodes[1].getreceivedbyaccount(account)["bitcoin"]
+        balance_by_account = self.nodes[1].getreceivedbyaccount(account)["CBT"]
 
         txid = self.nodes[0].sendtoaddress(addr, 0.1)
         self.sync_all()
@@ -117,7 +117,7 @@ class ReceivedByTest(BitcoinTestFramework):
                            received_by_account_json)
 
         # getreceivedbyaddress should return same balance because of 0 confirmations
-        balance = self.nodes[1].getreceivedbyaccount(account)["bitcoin"]
+        balance = self.nodes[1].getreceivedbyaccount(account)["CBT"]
         if balance != balance_by_account:
             raise AssertionError("Wrong balance returned by getreceivedbyaccount, %0.2f"%(balance))
 
@@ -126,10 +126,10 @@ class ReceivedByTest(BitcoinTestFramework):
         # listreceivedbyaccount should return updated account balance
         assert_array_result(self.nodes[1].listreceivedbyaccount(),
                            {"account":account},
-                           {"account":received_by_account_json["account"], "amount":{"bitcoin":(received_by_account_json["amount"]["bitcoin"] + Decimal("0.1"))}})
+                           {"account":received_by_account_json["account"], "amount":{"CBT":(received_by_account_json["amount"]["CBT"] + Decimal("0.1"))}})
 
         # getreceivedbyaddress should return updates balance
-        balance = self.nodes[1].getreceivedbyaccount(account)["bitcoin"]
+        balance = self.nodes[1].getreceivedbyaccount(account)["CBT"]
         if balance != balance_by_account + Decimal("0.1"):
             raise AssertionError("Wrong balance returned by getreceivedbyaccount, %0.2f"%(balance))
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -56,9 +56,9 @@ MOCKTIME = 0
 def enable_mocktime():
     #For backwared compatibility of the python scripts
     #with previous versions of the cache, set MOCKTIME 
-    #to Jan 1, 2014 + (201 * 10 * 60)
+    #to Jan 2, 2018 + (201 * 10 * 60)
     global MOCKTIME
-    MOCKTIME = 1388534400 + (201 * 10 * 60)
+    MOCKTIME = 1514851200 + (201 * 10 * 60)
 
 def disable_mocktime():
     global MOCKTIME

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -36,24 +36,24 @@ class WalletTest (BitcoinTestFramework):
         assert_equal(len(self.nodes[2].listunspent()), 100)
 
         walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['balance']["bitcoin"], 21000000)
+        assert_equal(walletinfo['balance']["CBT"], 21000000)
 
         print("Mining blocks...")
         self.nodes[1].generate(101)
         self.sync_all()
 
-        assert_equal(self.nodes[0].getbalance("", 0, False, "bitcoin"), 21000000)
-        assert_equal(self.nodes[1].getbalance("", 0, False, "bitcoin"), 21000000)
-        assert_equal(self.nodes[2].getbalance("", 0, False, "bitcoin"), 21000000)
+        assert_equal(self.nodes[0].getbalance("", 0, False, "CBT"), 21000000)
+        assert_equal(self.nodes[1].getbalance("", 0, False, "CBT"), 21000000)
+        assert_equal(self.nodes[2].getbalance("", 0, False, "CBT"), 21000000)
 
         #Set all OP_TRUE genesis outputs to single node
         self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 21000000, "", "", True)
         self.nodes[0].generate(101)
         self.sync_all()
 
-        assert_equal(self.nodes[0].getbalance("", 0, False, "bitcoin"), 21000000)
-        assert_equal(self.nodes[1].getbalance("", 0, False, "bitcoin"), 0)
-        assert_equal(self.nodes[2].getbalance("", 0, False, "bitcoin"), 0)
+        assert_equal(self.nodes[0].getbalance("", 0, False, "CBT"), 21000000)
+        assert_equal(self.nodes[1].getbalance("", 0, False, "CBT"), 0)
+        assert_equal(self.nodes[2].getbalance("", 0, False, "CBT"), 0)
 
         #self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1000000)
         #self.nodes[0].generate(1)
@@ -85,7 +85,7 @@ class WalletTest (BitcoinTestFramework):
         assert(not txout2v0['coinbase'])
         #assert_equal(amountcommit2, txout2v0['amountcommitment'])
 
-        walletinfo = self.nodes[0].getwalletinfo("bitcoin")
+        walletinfo = self.nodes[0].getwalletinfo("CBT")
         assert_equal(walletinfo['immature_balance'], 0)
 
         # Have node0 mine a block, thus it will collect its own fee. Confirm previous transactions.
@@ -93,7 +93,7 @@ class WalletTest (BitcoinTestFramework):
         self.sync_all()
 
         # Exercise locking of unspent outputs
-        unspent_0 = self.nodes[2].listunspent(1, 9999999, [], True, "bitcoin")[0]
+        unspent_0 = self.nodes[2].listunspent(1, 9999999, [], True, "CBT")[0]
         unspent_0 = {"txid": unspent_0["txid"], "vout": unspent_0["vout"]}
         self.nodes[2].lockunspent(False, [unspent_0])
         assert_raises_message(JSONRPCException, "Insufficient funds", self.nodes[2].sendtoaddress, self.nodes[2].getnewaddress(), 20)
@@ -107,13 +107,13 @@ class WalletTest (BitcoinTestFramework):
 
         # node0 should end up with 100 btc in block rewards plus fees, but
         # minus the 21 plus fees sent to node2
-        assert_equal(self.nodes[0].getbalance("", 0, False, "bitcoin"), 21000000-21)
-        assert_equal(self.nodes[2].getbalance("", 0, False, "bitcoin"), 21)
+        assert_equal(self.nodes[0].getbalance("", 0, False, "CBT"), 21000000-21)
+        assert_equal(self.nodes[2].getbalance("", 0, False, "CBT"), 21)
 
         # Node0 should have three spendable outputs since 0-value coinbase outputs will be OP_RETURN.
         # Create a couple of transactions to send them to node2, submit them through
         # node1, and make sure both node0 and node2 pick them up properly:
-        node0utxos = self.nodes[0].listunspent(1, 9999999, [], True, "bitcoin")
+        node0utxos = self.nodes[0].listunspent(1, 9999999, [], True, "CBT")
         assert_equal(len(node0utxos), 3)
 
         # create both transactions

--- a/qa/rpc-tests/zapwallettxes.py
+++ b/qa/rpc-tests/zapwallettxes.py
@@ -29,7 +29,7 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         self.nodes[1].generate(101)
         self.sync_all()
         
-        assert_equal(self.nodes[0].getbalance()["bitcoin"], 21000000)
+        assert_equal(self.nodes[0].getbalance()["CBT"], 21000000)
         
         txid0 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11)
         txid1 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10)

--- a/src/assetsdir.cpp
+++ b/src/assetsdir.cpp
@@ -28,7 +28,7 @@ void CAssetsDir::SetHex(const std::string& assetHex, const std::string& label)
     if (!IsHex(assetHex) || assetHex.size() != 64)
         throw std::runtime_error("The asset must be hex string of length 64");
 
-    const std::vector<std::string> protectedLabels = {"", "*", "bitcoin", "Bitcoin", "btc"};
+    const std::vector<std::string> protectedLabels = {"", "*", "CBT", "Cbt", "cbt"};
     for (std::string proLabel : protectedLabels) {
         if (label == proLabel) {
             throw std::runtime_error(strprintf("'%s' label is protected", proLabel));
@@ -47,8 +47,8 @@ void CAssetsDir::InitFromStrings(const std::vector<std::string>& assetsToInit)
         }
         SetHex(vAssets[0], vAssets[1]);
     }
-    // Set "bitcoin" to the pegged asset for tests
-    Set(Params().GetConsensus().pegged_asset, AssetMetadata("bitcoin"));
+    // Set "CBT" to the pegged asset for tests
+    Set(Params().GetConsensus().pegged_asset, AssetMetadata("CBT"));
 }
 
 CAsset CAssetsDir::GetAsset(const std::string& label) const

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -174,7 +174,7 @@ public:
         GenerateAssetEntropy(entropy,  COutPoint(uint256(commit), 0), parentGenesisBlockHash);
         CalculateAsset(consensus.pegged_asset, entropy);
 
-        genesis = CreateGenesisBlock(consensus, strNetworkID, 1296688602, genesisChallengeScript, 1);
+        genesis = CreateGenesisBlock(consensus, strNetworkID, 1514764800, genesisChallengeScript, 1);
         AppendInitialIssuance(genesis, COutPoint(uint256(commit), 0), parentGenesisBlockHash, 100, 21000000000000, 0, 0, CScript() << OP_TRUE);
         consensus.hashGenesisBlock = genesis.GetHash();
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -10,13 +10,13 @@
 
 #include <assert.h>
 
-const std::string CBaseChainParams::MAIN = CHAINPARAMS_OLD_MAIN;
+const std::string CBaseChainParams::MAIN = CHAINPARAMS_OCEAN_MAIN;
 const std::string CBaseChainParams::REGTEST = CHAINPARAMS_REGTEST;
 
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
 {
     strUsage += HelpMessageGroup(_("Chain selection options:"));
-    strUsage += HelpMessageOpt("-chain=<chain>", strprintf(_("Use the chain <chain> (default: %s). Allowed values: main, testnet, regtest, custom"), CHAINPARAMS_OLD_MAIN));
+    strUsage += HelpMessageOpt("-chain=<chain>", strprintf(_("Use the chain <chain> (default: %s). Allowed values: main, testnet, regtest, custom"), CHAINPARAMS_OCEAN_MAIN));
     if (debugHelp) {
         strUsage += HelpMessageOpt("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                                    "This is intended for regression testing tools and app development.");
@@ -51,5 +51,5 @@ std::string ChainNameFromCommandLine()
         throw std::runtime_error(strprintf("%s: Invalid option -testnet: try -chain=%s instead.", __func__, CHAINPARAMS_REGTEST));
     if (GetBoolArg("-regtest", false))
         return CBaseChainParams::REGTEST;
-    return GetArg("-chain", CHAINPARAMS_REGTEST);
+    return GetArg("-chain", CHAINPARAMS_OCEAN_MAIN);
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #define CHAINPARAMS_OLD_MAIN "___old_main"
+#define CHAINPARAMS_OCEAN_MAIN "ocean_main"
 #define CHAINPARAMS_REGTEST "elementsregtest"
 
 /**

--- a/src/test/assetsdir_tests.cpp
+++ b/src/test/assetsdir_tests.cpp
@@ -14,12 +14,12 @@ BOOST_FIXTURE_TEST_SUITE(assetsdir_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(assetsdirTests)
 {
     CAssetsDir tAssetsDir;
-    const std::string defaultPeggedLabel = "bitcoin";
+    const std::string defaultPeggedLabel = "CBT";
     const std::string defaultPeggedAssetHex = Params().GetConsensus().pegged_asset.GetHex();
     const CAsset defaultPeggedAsset = Params().GetConsensus().pegged_asset;
     const std::string exampleAssetHex = "fa821b0be5e1387adbcb69dbb3ad33edb5e470831c7c938c4e7b344edbe8bb11";
     const CAsset exampleAsset = CAsset(uint256S(exampleAssetHex));
-    const std::vector<std::string> protectedLabels = {"*", defaultPeggedLabel, "bitcoin", "Bitcoin", "btc"};
+    const std::vector<std::string> protectedLabels = {"*", defaultPeggedLabel, "CBT", "Cbt", "cbt"};
 
     for (std:: string protectedLabel : protectedLabels) {
         std::vector<std::string> assetsToInitProtected = {exampleAssetHex + ":" + protectedLabel};
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(assetsdirTests)
 
     BOOST_CHECK(exampleAsset == tAssetsDir.GetAsset("other"));
     BOOST_CHECK_EQUAL("other", tAssetsDir.GetLabel(exampleAsset));
-    // "bitcoin" is hardcoded for python tests
+    // "CBT" is hardcoded for python tests
     BOOST_CHECK(defaultPeggedAsset == tAssetsDir.GetAsset(defaultPeggedLabel));
     BOOST_CHECK_EQUAL(defaultPeggedLabel, tAssetsDir.GetLabel(defaultPeggedAsset));
     BOOST_CHECK(defaultPeggedAsset == tAssetsDir.GetAsset(tAssetsDir.GetLabel(CAsset(uint256S(defaultPeggedAssetHex)))));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -528,7 +528,7 @@ static std::string FormatException(const std::exception* pex, const char* pszThr
     char pszModule[MAX_PATH] = "";
     GetModuleFileNameA(NULL, pszModule, sizeof(pszModule));
 #else
-    const char* pszModule = "bitcoin";
+    const char* pszModule = "CBT";
 #endif
     if (pex)
         return strprintf(

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -558,7 +558,7 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
     if (request.params.size() > 4)
         fSubtractFeeFromAmount = request.params[4].get_bool();
 
-    std::string strasset = "bitcoin";
+    std::string strasset = "CBT";
     if (request.params.size() > 5 && request.params[5].isStr()) {
         strasset = request.params[5].get_str();
     }
@@ -1163,7 +1163,7 @@ UniValue sendmany(const JSONRPCRequest& request)
     {
         CBitcoinAddress address(name_);
 
-        std::string strasset = "bitcoin";
+        std::string strasset = "CBT";
         if (!assets.isNull() && assets[name_].isStr()) {
             strasset = assets[name_].get_str();
         }


### PR DESCRIPTION
@tomt1664 
I've so far replaced BTC with CBT as the host coin and changed the creation time to generate a custom genesis block.

There's currently an initial issuance of 21Mil CBT which is OP_TRUE (available to any wallet). I guess we'll need to change this in such a way that only the central node can spend these, so probably signing these with a private key which will then be imported to the main node wallet? 