### PR TITLE
Some fixes for CT and wallet 

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -461,7 +461,7 @@ UniValue validatederivedkeys(const JSONRPCRequest& request)
         if (!pubKey.IsFullyValid())
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid public key");
 
-        uint256 contract = chainActive.Tip() ? chainActive.Tip()->hashContract : GetContractHash();
+        uint256 contract = chainActive.Tip() ? chainActive.Tip()->hashContract : GetGenesisContractHash();
         pubKey.AddTweakToPubKey((unsigned char*)contract.begin()); 
         CKeyID keyId;
         if (!address.GetKeyID(keyId))

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3810,7 +3810,8 @@ UniValue issueasset(const JSONRPCRequest& request)
         keyID = newKey.GetID();
         pwalletMain->SetAddressBook(keyID, "", "receive");
         assetAddr = CBitcoinAddress(keyID);
-        assetKey = pwalletMain->GetBlindingPubKey(GetScriptForDestination(assetAddr.Get()));
+        assetKey = !pwalletMain->GetDisableCt() ? 
+            pwalletMain->GetBlindingPubKey(GetScriptForDestination(assetAddr.Get())) : CPubKey();
     }
     if (nTokens > 0) {
         if (!pwalletMain->GetKeyFromPool(newKey))
@@ -3818,7 +3819,8 @@ UniValue issueasset(const JSONRPCRequest& request)
         keyID = newKey.GetID();
         pwalletMain->SetAddressBook(keyID, "", "receive");
         tokenAddr = CBitcoinAddress(keyID);
-        tokenKey = pwalletMain->GetBlindingPubKey(GetScriptForDestination(CTxDestination(keyID)));
+        tokenKey = !pwalletMain->GetDisableCt() ? 
+            pwalletMain->GetBlindingPubKey(GetScriptForDestination(CTxDestination(keyID))) : CPubKey();
     }
 
     CWalletTx wtx;
@@ -3918,7 +3920,8 @@ UniValue reissueasset(const JSONRPCRequest& request)
     keyID = newKey.GetID();
     pwalletMain->SetAddressBook(keyID, "", "receive");
     assetAddr = CBitcoinAddress(keyID);
-    assetKey = pwalletMain->GetBlindingPubKey(GetScriptForDestination(assetAddr.Get()));
+    assetKey = !pwalletMain->GetDisableCt() ? 
+        pwalletMain->GetBlindingPubKey(GetScriptForDestination(assetAddr.Get())) : CPubKey();
 
     // Add destination for tokens we are moving
     if (!pwalletMain->GetKeyFromPool(newKey))
@@ -3926,7 +3929,8 @@ UniValue reissueasset(const JSONRPCRequest& request)
     keyID = newKey.GetID();
     pwalletMain->SetAddressBook(keyID, "", "receive");
     tokenAddr = CBitcoinAddress(keyID);
-    tokenKey = pwalletMain->GetBlindingPubKey(GetScriptForDestination(CTxDestination(keyID)));
+    tokenKey = !pwalletMain->GetDisableCt() ? 
+        pwalletMain->GetBlindingPubKey(GetScriptForDestination(CTxDestination(keyID))) : CPubKey();
 
     // Attempt a send.
     CWalletTx wtx;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -116,7 +116,8 @@ CPubKey CWallet::GenerateNewKey()
     metadata.derivedPubKey = pubKeyPreTweak;
 
     if (Params().EmbedContract()) {
-        uint256 contract = chainActive.Tip() ? chainActive.Tip()->hashContract : uint256(); // for BIP-175
+        // use the active block contract hash to generate keys - if this is not available use the genesis block contract
+        uint256 contract = chainActive.Tip() ? chainActive.Tip()->hashContract : GetGenesisContractHash(); // for BIP-175
         pubKeyPreTweak.AddTweakToPubKey((unsigned char*)contract.begin()); //tweak pubkey for reverse testing
         secret.AddTweakToPrivKey((unsigned char*)contract.begin()); //do actual tweaking of private key
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2972,7 +2972,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                             }
 
                             vector<CTxOut>::iterator position = txNew.vout.begin()+nChangePosInOut;
-                            CPubKey pubkey = GetBlindingPubKey(scriptChange);
+                            CPubKey pubkey = !GetDisableCt() ? GetBlindingPubKey(scriptChange) : CPubKey();
                             newTxOut.nNonce.vchCommitment = std::vector<unsigned char>(pubkey.begin(), pubkey.end());
                             txNew.vout.insert(position, newTxOut);
                             output_pubkeys.insert(output_pubkeys.begin() + nChangePosInOut, pubkey);


### PR DESCRIPTION
Make confidential addresses optional when issuing assets
Make wallet use the genesis contract hash when the chain is not active. It was previously using the local contract file, which might not be available/up to date in client wallets.