### PR TITLE
Issuance block

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -384,6 +384,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), DEFAULT_PERMIT_BAREMULTISIG));
     strUsage += HelpMessageOpt("-pkhwhitelist", strprintf(_("Enable node mempool address whitelisting (default: %u)"), DEFAULT_WHITELIST_CHECK));
+    strUsage += HelpMessageOpt("-issuanceblock", strprintf(_("Enable node mempool issuance transaction blocking (default: %u)"), DEFAULT_BLOCK_ISSUANCE));
     strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with bloom filters (default: %u)"), DEFAULT_PEERBLOOMFILTERS));
     strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u)"), defaultChainParams->GetDefaultPort()));
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
@@ -1072,6 +1073,7 @@ bool AppInitParameterInteraction()
 #endif
 
     fRequireWhitelistCheck = GetBoolArg("-pkhwhitelist", DEFAULT_WHITELIST_CHECK);
+    fblockissuancetx = GetBoolArg("-issuanceblock", DEFAULT_BLOCK_ISSUANCE);
     fIsBareMultisigStd = GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
     fAcceptDatacarrier = GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);
     nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -79,6 +79,7 @@ bool fPruneMode = false;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 bool fRequireStandard = true;
 bool fRequireWhitelistCheck = DEFAULT_WHITELIST_CHECK;
+bool fblockissuancetx = DEFAULT_BLOCK_ISSUANCE;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
 size_t nCoinCacheUsage = 5000 * 300;
@@ -1085,6 +1086,13 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
     if (fRequireWhitelistCheck){
       if(!IsWhitelisted(tx))
       return state.DoS(0, false, REJECT_NONSTANDARD, "non-whitelisted-address");
+    }
+
+    // Accept only transactions that have no asset issuance inputs
+    if(fblockissuancetx){
+      if(GetNumIssuances(tx) > 0){
+	return state.DoS(0, false, REJECT_NONSTANDARD, "blocked-asset-issuance-txn");
+      }
     }
 
     // Only accept nLockTime-using transactions that can be mined in the next

--- a/src/validation.h
+++ b/src/validation.h
@@ -130,6 +130,7 @@ static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 static const int64_t MAX_FEE_ESTIMATION_TIP_AGE = 3 * 60 * 60;
 
 static const bool DEFAULT_WHITELIST_CHECK = false;
+static const bool DEFAULT_BLOCK_ISSUANCE = false;
 
 /** Default for -permitbaremultisig */
 static const bool DEFAULT_PERMIT_BAREMULTISIG = true;
@@ -174,6 +175,7 @@ extern int nScriptCheckThreads;
 extern bool fTxIndex;
 extern bool fIsBareMultisigStd;
 extern bool fRequireWhitelistCheck;
+extern bool fblockissuancetx;
 extern bool fRequireStandard;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;


### PR DESCRIPTION
added configuration option to block asset issuance transactions to mempool

-issuanceblock=1 will prevent a transaction that has any asset issuance transactions from entering the mempool. 

This can be used to stop asset issuance transactions created by public wallets from reaching signing nodes (so only authorised issuance nodes connected directly to the signing nodes can issue assets). 