### PR TITLE
Ocean fee changes

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -150,7 +150,7 @@ testScripts = [
     'invalidblockrequest.py',
     'invalidtxrequest.py',
     'rpc_getblockstats.py',
-    #'confidential_transactions.py', #until confidential transactions are re enabled
+    'confidential_transactions.py',
     'preciousblock.py',
     #'p2p-segwit.py',
     #'importprunedfunds.py',

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -124,7 +124,8 @@ class WalletTest (BitcoinTestFramework):
             inputs = []
             outputs = {}
             inputs.append({ "txid" : utxo["txid"], "vout" : utxo["vout"], "nValue":utxo["amount"]})
-            outputs[self.nodes[2].getnewaddress("from1")] = utxo["amount"]
+            outputs = {self.nodes[2].getnewaddress("from1"): utxo["amount"] - Decimal('1'),
+                        "fee": Decimal('1')}
             raw_tx = self.nodes[0].createrawtransaction(inputs, outputs)
             raw_tx = self.nodes[0].blindrawtransaction(raw_tx)
             txns_to_send.append(self.nodes[0].signrawtransaction(raw_tx))
@@ -164,7 +165,7 @@ class WalletTest (BitcoinTestFramework):
         node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), Decimal('20'), fee_per_byte, count_bytes(self.nodes[2].getrawtransaction(txid)))
 
         # Sendmany 10 BTC
-        txid = self.nodes[2].sendmany('from1', {address: 10}, 0, "", [])
+        txid = self.nodes[2].sendmany('from1', {address: 10}, 0, "", [], {'fee': 'CBT'})
         self.nodes[2].generate(1)
         self.sync_all()
         node_0_bal += Decimal('10')
@@ -172,7 +173,7 @@ class WalletTest (BitcoinTestFramework):
         assert_equal(self.nodes[0].getbalance(), node_0_bal)
 
         # Sendmany 10 BTC with subtract fee from amount
-        txid = self.nodes[2].sendmany('from1', {address: 10}, 0, "", [address])
+        txid = self.nodes[2].sendmany('from1', {address: 10}, 0, "", [address], {'fee': 'CBT'})
         self.nodes[2].generate(1)
         self.sync_all()
         node_2_bal -= Decimal('10')

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -53,7 +53,7 @@ static void CoinSelection(benchmark::State& state)
         CAmountMap nValueRet;
         CAmountMap mapValue;
         mapValue[Params().GetConsensus().pegged_asset] = 1003 * COIN;
-        bool success = wallet.SelectCoinsMinConf(mapValue, 1, 6, 0, vCoins, setCoinsRet, nValueRet);
+        bool success = wallet.SelectCoinsMinConf(mapValue, 1, 6, 0, vCoins, setCoinsRet, nValueRet, Params().GetConsensus().pegged_asset);
         assert(success);
         assert(nValueRet[Params().GetConsensus().pegged_asset] == 1003 * COIN);
         assert(setCoinsRet.size() == 2);

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -19,8 +19,7 @@ static void AddTx(const CTransaction& tx, const CAmount& nFee, CTxMemPool& pool)
     std::set<std::pair<uint256, COutPoint> > setPeginsSpent;
     LockPoints lp;
     pool.addUnchecked(tx.GetHash(), CTxMemPoolEntry(
-                                        MakeTransactionRef(tx), nFee, nTime, dPriority, nHeight,
-                                        0, spendsCoinbase, sigOpCost, lp, setPeginsSpent));
+                                        MakeTransactionRef(tx), nFee, CAsset(), nTime, dPriority, nHeight, 0, spendsCoinbase, sigOpCost, lp, setPeginsSpent));
 }
 
 // Right now this is only testing eviction performance in an extremely small

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -122,7 +122,7 @@ void BlockAssembler::resetBlock()
 
     // These counters do not include coinbase tx
     nBlockTx = 0;
-    nFees = 0;
+    nFees = CAmountMap();
 
     lastFewTxs = 0;
     blockFinished = false;
@@ -208,17 +208,34 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     CMutableTransaction coinbaseTx;
     coinbaseTx.vin.resize(1);
     coinbaseTx.vin[0].prevout.SetNull();
-    coinbaseTx.vout.resize(1);
-    coinbaseTx.vout[0].scriptPubKey = nFees ? scriptPubKeyIn : CScript() << OP_RETURN;
-    coinbaseTx.vout[0].nValue = nFees;
-    coinbaseTx.vout[0].nAsset = policyAsset;
     coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
+    coinbaseTx.vout.resize(1);
+    CAmount nFeeSum = 0;
+    if (!nFees.empty())
+    {
+        coinbaseTx.vout.resize(nFees.size());
+        int nCount = 0;
+        for (auto const& fee : nFees)
+        {
+            coinbaseTx.vout[nCount].scriptPubKey = fee.second ? scriptPubKeyIn : CScript() << OP_RETURN;
+            coinbaseTx.vout[nCount].nValue = fee.second;
+            coinbaseTx.vout[nCount].nAsset = fee.second ? fee.first : policyAsset;
+            nFeeSum += fee.second;
+            nCount++;
+        }
+    }
+    else
+    {
+        coinbaseTx.vout[0].scriptPubKey = CScript() << OP_RETURN;
+        coinbaseTx.vout[0].nValue = 0;
+        coinbaseTx.vout[0].nAsset = policyAsset;
+    }
     pblock->vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
     pblocktemplate->vchCoinbaseCommitment = GenerateCoinbaseCommitment(*pblock, pindexPrev, chainparams.GetConsensus());
-    pblocktemplate->vTxFees[0] = -nFees;
+    pblocktemplate->vTxFees[0] = -nFeeSum;
 
     uint64_t nSerializeSize = GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION);
-    LogPrintf("CreateNewBlock(): total size: %u block weight: %u txs: %u fees: %ld sigops %d\n", nSerializeSize, GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);
+    LogPrintf("CreateNewBlock(): total size: %u block weight: %u txs: %u fees: %ld sigops %d\n", nSerializeSize, GetBlockWeight(*pblock), nBlockTx, nFeeSum, nBlockSigOpsCost);
 
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
@@ -358,7 +375,7 @@ void BlockAssembler::AddToBlock(CTxMemPool::txiter iter)
     nBlockWeight += iter->GetTxWeight();
     ++nBlockTx;
     nBlockSigOpsCost += iter->GetSigOpCost();
-    nFees += iter->GetFee();
+    nFees[iter->GetFeeAsset()] += iter->GetFee();
     inBlock.insert(iter);
 
     bool fPrintPriority = GetBoolArg("-printpriority", DEFAULT_PRINTPRIORITY);

--- a/src/miner.h
+++ b/src/miner.h
@@ -150,7 +150,7 @@ private:
     uint64_t nBlockSize;
     uint64_t nBlockTx;
     uint64_t nBlockSigOpsCost;
-    CAmount nFees;
+    CAmountMap nFees;
     CTxMemPool::setEntries inBlock;
 
     // Chain context for the block

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -20,7 +20,7 @@ CAsset policyAsset;
     /**
      * Check transaction inputs to mitigate two
      * potential denial-of-service attacks:
-     * 
+     *
      * 1. scriptSigs with extra data stuffed into them,
      *    not consumed by scriptPubKey (or P2SH script)
      * 2. P2SH scripts with a crazy number of expensive
@@ -93,7 +93,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
         if ((whichType == TX_MULTISIG) && (!fIsBareMultisigStd)) {
             reason = "bare-multisig";
             return false;
-        } else if ((txout.nAsset.IsExplicit() && txout.nAsset.GetAsset() == policyAsset) && txout.IsDust(dustRelayFee)) {
+        } else if (txout.nAsset.IsExplicit() && txout.IsDust(dustRelayFee)) {
             reason = "dust";
             return false;
         }
@@ -123,7 +123,7 @@ bool IsWhitelisted(const CTransaction& tx)
     CKeyID keyId;
     keyId = CKeyID(uint160(vSolutions[0]));
 
-    // search in whitelist for the presence of qaddress: if not found return false                                                                    
+    // search in whitelist for the presence of qaddress: if not found return false
 
     if(!(std::binary_search(addressWhitelist.begin(),addressWhitelist.end(),keyId))) return false;
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1820,8 +1820,6 @@ static UniValue getblockstats(const JSONRPCRequest& request)
         }
     }
 
-    const CAsset asset = policyAsset; // TODO Make configurable
-
     const CBlock block = GetBlockChecked(pindex);
 
     const bool do_all = stats.size() == 0; // Calculate everything if nothing selected (default)
@@ -1873,10 +1871,10 @@ static UniValue getblockstats(const JSONRPCRequest& request)
 
         if (loop_outputs) {
             for (const CTxOut& out : tx->vout) {
-                if (out.IsFee() && out.nAsset.GetAsset() == asset) {
+                if (out.IsFee()) {
                     txfee += out.nValue.GetAmount();
                 }
-                if (out.nValue.IsExplicit() && out.nAsset.IsExplicit() && out.nAsset.GetAsset() == asset) {
+                if (out.nValue.IsExplicit() && out.nAsset.IsExplicit()) {
                     tx_total_out += out.nValue.GetAmount();
                 }
             }

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -182,7 +182,7 @@ CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CTransaction &txn, CTxMemPo
     // Hack to assume either it's completely dependent on other mempool txs or not at all
     CAmount inChainValue = pool && pool->HasNoInputsOf(txn) ? TotalValueOut(txn) : 0;
 
-    return CTxMemPoolEntry(MakeTransactionRef(txn), nFee, nTime, dPriority, nHeight,
+    return CTxMemPoolEntry(MakeTransactionRef(txn), nFee, feeAsset, nTime, dPriority, nHeight,
                            inChainValue, spendsCoinbase, sigOpCost, lp, setPeginsSpent);
 }
 

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -67,6 +67,7 @@ struct TestMemPoolEntryHelper
 {
     // Default values
     CAmount nFee;
+    CAsset feeAsset;
     int64_t nTime;
     double dPriority;
     unsigned int nHeight;
@@ -76,14 +77,15 @@ struct TestMemPoolEntryHelper
     std::set<std::pair<uint256, COutPoint> > setPeginsSpent;
 
     TestMemPoolEntryHelper() :
-        nFee(0), nTime(0), dPriority(0.0), nHeight(1),
+        nFee(0), feeAsset(CAsset()), nTime(0), dPriority(0.0), nHeight(1),
         spendsCoinbase(false), sigOpCost(4) { }
-    
+
     CTxMemPoolEntry FromTx(const CMutableTransaction &tx, CTxMemPool *pool = NULL);
     CTxMemPoolEntry FromTx(const CTransaction &tx, CTxMemPool *pool = NULL);
 
     // Change the default value
     TestMemPoolEntryHelper &Fee(CAmount _fee) { nFee = _fee; return *this; }
+    TestMemPoolEntryHelper &FeeAsset(CAsset _feeAsset) { feeAsset = _feeAsset; return *this; }
     TestMemPoolEntryHelper &Time(int64_t _time) { nTime = _time; return *this; }
     TestMemPoolEntryHelper &Priority(double _priority) { dPriority = _priority; return *this; }
     TestMemPoolEntryHelper &Height(unsigned int _height) { nHeight = _height; return *this; }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -18,11 +18,11 @@
 #include "utiltime.h"
 #include "version.h"
 
-CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,
+CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee, const CAsset& _feeAsset,
                                  int64_t _nTime, double _entryPriority, unsigned int _entryHeight,
                                  CAmount _inChainInputValue,
                                  bool _spendsCoinbase, int64_t _sigOpsCost, LockPoints lp, std::set<std::pair<uint256, COutPoint> >& _setPeginsSpent):
-    tx(_tx), nFee(_nFee), nTime(_nTime), entryPriority(_entryPriority), entryHeight(_entryHeight),
+    tx(_tx), nFee(_nFee), feeAsset(_feeAsset), nTime(_nTime), entryPriority(_entryPriority), entryHeight(_entryHeight),
     inChainInputValue(_inChainInputValue),
     spendsCoinbase(_spendsCoinbase), sigOpCost(_sigOpsCost), lockPoints(lp), setPeginsSpent(_setPeginsSpent)
 {
@@ -305,7 +305,7 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, b
         // should be a bit faster.
         // However, if we happen to be in the middle of processing a reorg, then
         // the mempool can be in an inconsistent state.  In this case, the set
-        // of ancestors reachable via mapLinks will be the same as the set of 
+        // of ancestors reachable via mapLinks will be the same as the set of
         // ancestors whose packages include this transaction, because when we
         // add a new transaction to the mempool in addUnchecked(), we assume it
         // has no children, and in the case of a reorg where that assumption is

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -84,6 +84,7 @@ class CTxMemPoolEntry
 private:
     CTransactionRef tx;
     CAmount nFee;              //!< Cached to avoid expensive parent-transaction lookups
+    CAsset feeAsset;           //!< Needed along with the fee for Ocean mempool entries
     size_t nTxWeight;          //!< ... and avoid recomputing tx weight (also used for GetTxSize())
     size_t nModSize;           //!< ... and modified size for priority
     size_t nUsageSize;         //!< ... and total memory usage
@@ -113,11 +114,7 @@ private:
 
 public:
     std::set<std::pair<uint256, COutPoint> > setPeginsSpent;
-    CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,
-
-                    int64_t _nTime, double _entryPriority, unsigned int _entryHeight,
-                    CAmount _inChainInputValue, bool spendsCoinbase,
-                    int64_t nSigOpsCost, LockPoints lp, std::set<std::pair<uint256, COutPoint> >& setPeginsSpent);
+    CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee, const CAsset& _feeAsset, int64_t _nTime, double _entryPriority, unsigned int _entryHeight, CAmount _inChainInputValue, bool spendsCoinbase, int64_t nSigOpsCost, LockPoints lp, std::set<std::pair<uint256, COutPoint> >& setPeginsSpent);
 
     CTxMemPoolEntry(const CTxMemPoolEntry& other);
 
@@ -129,6 +126,7 @@ public:
      */
     double GetPriority(unsigned int currentHeight) const;
     const CAmount& GetFee() const { return nFee; }
+    const CAsset& GetFeeAsset() const { return feeAsset; }
     size_t GetTxSize() const;
     size_t GetTxWeight() const { return nTxWeight; }
     int64_t GetTime() const { return nTime; }
@@ -660,7 +658,7 @@ public:
 
     /** Estimate priority needed to get into the next nBlocks */
     double estimatePriority(int nBlocks) const;
-    
+
     /** Write/Read estimates to disk */
     bool WriteFeeEstimates(CAutoFile& fileout) const;
     bool ReadFeeEstimates(CAutoFile& filein);
@@ -709,7 +707,7 @@ private:
     void removeUnchecked(txiter entry, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
 };
 
-/** 
+/**
  * CCoinsView that brings transactions from a memorypool into view.
  * It does not check for spendings by memory pool transactions.
  */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -624,7 +624,7 @@ private:
      * all coins from coinControl are selected; Never select unconfirmed coins
      * if they are not ours
      */
-    bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmountMap& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmountMap& nValueRet, const CCoinControl* coinControl) const;
+    bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmountMap& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmountMap& nValueRet, const CCoinControl* coinControl, const CAsset& feeAsset) const;
 
     CWalletDB *pwalletdbEncryption;
 
@@ -779,7 +779,7 @@ public:
      * completion the coin set and corresponding actual target value is
      * assembled
      */
-    bool SelectCoinsMinConf(const CAmountMap& nTargetValue, int nConfMine, int nConfTheirs, uint64_t nMaxAncestors, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmountMap& nValueRet) const;
+    bool SelectCoinsMinConf(const CAmountMap& nTargetValue, int nConfMine, int nConfTheirs, uint64_t nMaxAncestors, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmountMap& nValueRet, const CAsset& feeAsset) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;
 
@@ -874,7 +874,7 @@ public:
      * @note passing nChangePosInOut as -1 will result in setting a random position
      */
     bool CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletTx& wtxNew, std::vector<CReserveKey>& vChangeKey, CAmount& nFeeRet, int& nChangePosInOut,
-                           std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true, std::vector<CAmount> *outAmounts = NULL, bool fBlindIssuances = true, const uint256* issuanceEntropy = NULL, const CAsset* reissuanceAsset = NULL, const CAsset* reissuanceToken = NULL, bool fIgnoreBlindFail = true);
+                           std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true, std::vector<CAmount> *outAmounts = NULL, bool fBlindIssuances = true, const uint256* issuanceEntropy = NULL, const CAsset* reissuanceAsset = NULL, const CAsset* reissuanceToken = NULL, CAsset feeAsset = CAsset(), bool fIgnoreBlindFail = true);
     bool CommitTransaction(CWalletTx& wtxNew, std::vector<CReserveKey>& reservekey, CConnman* connman, CValidationState& state);
 
     void ListAccountCreditDebit(const std::string& strAccount, std::list<CAccountingEntry>& entries);


### PR DESCRIPTION
Mempool entries include fee asset information
Coinbase includes fees on multiple asset ids
Sendtransaction to pay fees on the asset send, sendmany to include an option for fee asset (else first asset chosen)
Issue/reissue/destroy to still use the policy asset
Re-enable confidential_transactions unit test in order to test issuance related transactions