### PR TITLE
new raw issuance rpc

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3764,6 +3764,113 @@ UniValue claimpegin(const JSONRPCRequest& request)
     return sendrawtransaction(request3);
 }
 
+UniValue createrawissuance(const JSONRPCRequest& request)
+{
+  if (request.fHelp || request.params.size() !=9)
+    throw runtime_error(
+            "createrawissuance assetaddress assetamount tokenaddress tokenamount changeaddress feeamount inputtxid vout\n"
+            "\nCreate a raw unsigned asset issuance transaction to specified addresses with a policyAsset outpoint as input.\n"
+            "\nArguments:\n"
+	    "1. \"assetaddress\"          (string, required) Address to send issued asset to.\n"
+            "2. \"assetamount\"           (numeric or string, required) Amount of asset to generate.\n"
+	    "3. \"tokenaddress\"          (string, required) Address to send reissuance token to.\n"
+            "4. \"tokenamount\"           (numeric or string, required) Amount of reissuance tokens to generate. These will allow you to reissue the asset if in wallet using `reissueasset`. These tokens are not consumed during reissuance.\n"
+	    "5. \"changeaddress\"         (string, required) Address to return the policyAsset input.\n"
+	    "6. \"changeamount\"          (numeric or string, required) Return policyAsset amount.\n"
+	    "7. \"feeamount\"             (numeric or string, required) Feen output amount.\n"
+            "8. \"inputtxid\"             (string, required) policyAsset input TXID.\n"
+	    "9. \"vout\"                  (numeric or string, required) policyAsset TXID output index\n"
+            "\nResult:\n"
+            "{                        (json object)\n"
+            "  \"rawtx\":\"<rawtx>\",   (string) Hex encoded raw unsigned issuance transaction.\n"
+            "  \"entropy\":\"<entropy>\" (string) Entropy of the asset type.\n"
+            "  \"asset\":\"<asset>\", (string) Asset type for issuance if known.\n"
+            "  \"token\":\"<token>\", (string) Token type for issuance.\n"
+            "}\n"
+            "\nExamples:\n"
+            + HelpExampleCli("createrawissuance", "\"2dhfx249gZKqMGKtKAgceuCyDiHVEeVZWzU\" 100.0 \"2dp5EWgkc4RyzVvBvAyRAMuJ1hS84BgSBLj\" 1.0 \"2djpn7hq9Jh3jx3sjhPXuhUpJQWHrtXrKLr\" 99.9995 0.0005 \"42b7101f4596d39cfb5f5e5ca7b6873474607b04f365590f478261ad74dae717\" 1 ")
+            + HelpExampleRpc("createrawissuance", "\"2dhfx249gZKqMGKtKAgceuCyDiHVEeVZWzU\" 100.0 \"2dp5EWgkc4RyzVvBvAyRAMuJ1hS84BgSBLj\" 1.0 \"2djpn7hq9Jh3jx3sjhPXuhUpJQWHrtXrKLr\" 99.9995 0.0005 \"42b7101f4596d39cfb5f5e5ca7b6873474607b04f365590f478261ad74dae717\" 1 ")
+			);
+  //Get the output addresses
+  CBitcoinAddress assetAddr(request.params[0].get_str());
+  CBitcoinAddress tokenAddr(request.params[2].get_str());
+  CBitcoinAddress changeAddr(request.params[4].get_str());
+
+  if (!assetAddr.IsValid())
+    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Asset token address");
+
+  if (!tokenAddr.IsValid())
+    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Reissuance token address");
+
+  if (!changeAddr.IsValid())
+    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid policy asset return address");
+
+  //get the output amounts
+  CAmount nAmount = AmountFromValue(request.params[1]);
+  CAmount nTokens = AmountFromValue(request.params[3]);
+  CAmount nChange = AmountFromValue(request.params[5]);
+  CAmount nFee = AmountFromValue(request.params[6]);
+
+  if (nAmount == 0 && nTokens == 0) {
+    throw JSONRPCError(RPC_TYPE_ERROR, "Issuance must have one non-zero component");
+  }
+
+  bool fBlindIssuances = false;
+
+  //get the input outpoint from RPC
+  uint256 prevtxhash;
+  prevtxhash.SetHex(request.params[7].get_str());
+  uint32_t nout = atoi(request.params[8].get_str());
+  COutPoint policyOutpoint(prevtxhash,nout);
+
+  uint256 dummyentropy;
+  CAsset dummyasset;
+  CMutableTransaction rawTx;
+
+  // Calculate entropy, asset and token IDs from the input outpoint
+  uint256 entropy;
+  CAsset asset;
+  CAsset token;
+  GenerateAssetEntropy(entropy, policyOutpoint, uint256());
+  CalculateAsset(asset, entropy);
+  CalculateReissuanceToken(token, entropy, fBlindIssuances);
+
+  //generate the outputs
+  CAsset pAsset(policyAsset);
+  CTxOut txoutAsset(asset,nAmount,GetScriptForDestination(assetAddr.Get()));
+  CTxOut txoutToken(token,nTokens,GetScriptForDestination(tokenAddr.Get()));
+  CTxOut txoutChange(pAsset,nChange,GetScriptForDestination(changeAddr.Get()));
+  CTxOut out(pAsset, nFee, CScript());
+
+  //push outputs to empty raw transaction
+  rawTx.vout.push_back(txoutAsset);
+  rawTx.vout.push_back(txoutToken);
+  rawTx.vout.push_back(txoutChange);
+  rawTx.vout.push_back(out);
+
+  //standard sequence number
+  uint32_t nSequence = (rawTx.nLockTime ? std::numeric_limits<uint32_t>::max() - 1 : std::numeric_limits<uint32_t>::max());
+
+  //generate input from the provided outpoint
+  CTxIn in(policyOutpoint, CScript(), nSequence);
+
+  //push single input to raw transaction
+  rawTx.vin.push_back(in);
+
+  //set flags and amounts for asset issuance and reissuance token in the input
+  rawTx.vin[0].assetIssuance.nAmount = nAmount;
+  rawTx.vin[0].assetIssuance.nInflationKeys = nTokens;
+
+  //return result
+  UniValue ret(UniValue::VOBJ);
+  ret.push_back(Pair("rawtx", EncodeHexTx(rawTx)));
+  ret.push_back(Pair("vin", 0));
+  ret.push_back(Pair("entropy", entropy.GetHex()));
+  ret.push_back(Pair("asset", asset.GetHex()));
+  ret.push_back(Pair("token", token.GetHex()));
+  return ret;
+}
+
 UniValue issueasset(const JSONRPCRequest& request)
 {
     if (!EnsureWalletIsAvailable(request.fHelp))
@@ -4136,6 +4243,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "importissuanceblindingkey",&importissuanceblindingkey,true,   {"txid", "vin", "blindingkey"} },
     { "wallet",             "keypoolrefill",            &keypoolrefill,            true,   {"newsize"} },
     { "wallet",             "issueasset",               &issueasset,               true,   {"assetamount", "tokenamount", "blind"} },
+    { "wallet",             "createrawissuance",        &createrawissuance,        true,   {"assetaddress", "assetamount", "tokenaddress", "tokenamount", "changeaddress", "changeamount", "feeamount", "inputtxid", "vout"} },
     { "wallet",             "listaccounts",             &listaccounts,             false,  {"minconf","include_watchonly"} },
     { "wallet",             "listaddressgroupings",     &listaddressgroupings,     false,  {} },
     { "wallet",             "listlockunspent",          &listlockunspent,          false,  {} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3766,7 +3766,7 @@ UniValue claimpegin(const JSONRPCRequest& request)
 
 UniValue createrawissuance(const JSONRPCRequest& request)
 {
-  if (request.fHelp || request.params.size() !=9)
+  if (request.fHelp || request.params.size() !=10)
     throw runtime_error(
             "createrawissuance assetaddress assetamount tokenaddress tokenamount changeaddress feeamount inputtxid vout\n"
             "\nCreate a raw unsigned asset issuance transaction to specified addresses with a policyAsset outpoint as input.\n"
@@ -3777,9 +3777,10 @@ UniValue createrawissuance(const JSONRPCRequest& request)
             "4. \"tokenamount\"           (numeric or string, required) Amount of reissuance tokens to generate. These will allow you to reissue the asset if in wallet using `reissueasset`. These tokens are not consumed during reissuance.\n"
 	    "5. \"changeaddress\"         (string, required) Address to return the policyAsset input.\n"
 	    "6. \"changeamount\"          (numeric or string, required) Return policyAsset amount.\n"
-	    "7. \"feeamount\"             (numeric or string, required) Feen output amount.\n"
-            "8. \"inputtxid\"             (string, required) policyAsset input TXID.\n"
-	    "9. \"vout\"                  (numeric or string, required) policyAsset TXID output index\n"
+	    "7. \"changenum\"             (numeric or string, required) Number of change outputs to be generated\n"
+	    "8. \"feeamount\"             (numeric or string, required) Fee output amount.\n"
+            "9. \"inputtxid\"             (string, required) policyAsset input TXID.\n"
+	    "10. \"vout\"                  (numeric or string, required) policyAsset TXID output index\n"
             "\nResult:\n"
             "{                        (json object)\n"
             "  \"rawtx\":\"<rawtx>\",   (string) Hex encoded raw unsigned issuance transaction.\n"
@@ -3788,8 +3789,8 @@ UniValue createrawissuance(const JSONRPCRequest& request)
             "  \"token\":\"<token>\", (string) Token type for issuance.\n"
             "}\n"
             "\nExamples:\n"
-            + HelpExampleCli("createrawissuance", "\"2dhfx249gZKqMGKtKAgceuCyDiHVEeVZWzU\" 100.0 \"2dp5EWgkc4RyzVvBvAyRAMuJ1hS84BgSBLj\" 1.0 \"2djpn7hq9Jh3jx3sjhPXuhUpJQWHrtXrKLr\" 99.9995 0.0005 \"42b7101f4596d39cfb5f5e5ca7b6873474607b04f365590f478261ad74dae717\" 1 ")
-            + HelpExampleRpc("createrawissuance", "\"2dhfx249gZKqMGKtKAgceuCyDiHVEeVZWzU\" 100.0 \"2dp5EWgkc4RyzVvBvAyRAMuJ1hS84BgSBLj\" 1.0 \"2djpn7hq9Jh3jx3sjhPXuhUpJQWHrtXrKLr\" 99.9995 0.0005 \"42b7101f4596d39cfb5f5e5ca7b6873474607b04f365590f478261ad74dae717\" 1 ")
+            + HelpExampleCli("createrawissuance", "\"2dhfx249gZKqMGKtKAgceuCyDiHVEeVZWzU\" 100.0 \"2dp5EWgkc4RyzVvBvAyRAMuJ1hS84BgSBLj\" 1.0 \"2djpn7hq9Jh3jx3sjhPXuhUpJQWHrtXrKLr\" 99.9995 1 0.0005 \"42b7101f4596d39cfb5f5e5ca7b6873474607b04f365590f478261ad74dae717\" 1 ")
+            + HelpExampleRpc("createrawissuance", "\"2dhfx249gZKqMGKtKAgceuCyDiHVEeVZWzU\" 100.0 \"2dp5EWgkc4RyzVvBvAyRAMuJ1hS84BgSBLj\" 1.0 \"2djpn7hq9Jh3jx3sjhPXuhUpJQWHrtXrKLr\" 99.9995 1 0.0005 \"42b7101f4596d39cfb5f5e5ca7b6873474607b04f365590f478261ad74dae717\" 1 ")
 			);
   //Get the output addresses
   CBitcoinAddress assetAddr(request.params[0].get_str());
@@ -3809,22 +3810,23 @@ UniValue createrawissuance(const JSONRPCRequest& request)
   CAmount nAmount = AmountFromValue(request.params[1]);
   CAmount nTokens = AmountFromValue(request.params[3]);
   CAmount nChange = AmountFromValue(request.params[5]);
-  CAmount nFee = AmountFromValue(request.params[6]);
+  CAmount nFee = AmountFromValue(request.params[7]);
 
   if (nAmount == 0 && nTokens == 0) {
     throw JSONRPCError(RPC_TYPE_ERROR, "Issuance must have one non-zero component");
   }
 
+  //get number of change outputs required
+  int nChangeOutputs = request.params[6].get_int();
+
   bool fBlindIssuances = false;
 
   //get the input outpoint from RPC
   uint256 prevtxhash;
-  prevtxhash.SetHex(request.params[7].get_str());
-  uint32_t nout = atoi(request.params[8].get_str());
+  prevtxhash.SetHex(request.params[8].get_str());
+  uint32_t nout = atoi(request.params[9].get_str());
   COutPoint policyOutpoint(prevtxhash,nout);
 
-  uint256 dummyentropy;
-  CAsset dummyasset;
   CMutableTransaction rawTx;
 
   // Calculate entropy, asset and token IDs from the input outpoint
@@ -3838,14 +3840,15 @@ UniValue createrawissuance(const JSONRPCRequest& request)
   //generate the outputs
   CAsset pAsset(policyAsset);
   CTxOut txoutAsset(asset,nAmount,GetScriptForDestination(assetAddr.Get()));
-  CTxOut txoutToken(token,nTokens,GetScriptForDestination(tokenAddr.Get()));
-  CTxOut txoutChange(pAsset,nChange,GetScriptForDestination(changeAddr.Get()));
-  CTxOut out(pAsset, nFee, CScript());
-
-  //push outputs to empty raw transaction
   rawTx.vout.push_back(txoutAsset);
+  CTxOut txoutToken(token,nTokens,GetScriptForDestination(tokenAddr.Get()));
   rawTx.vout.push_back(txoutToken);
-  rawTx.vout.push_back(txoutChange);
+  CTxOut txoutChange(pAsset,nChange,GetScriptForDestination(changeAddr.Get()));
+  vector<CTxOut> changeOuts;
+  for(int it=0;it<nChangeOutputs;it++) {
+    rawTx.vout.push_back(txoutChange);
+  }
+  CTxOut out(pAsset, nFee, CScript());
   rawTx.vout.push_back(out);
 
   //standard sequence number


### PR DESCRIPTION
A new RPC that generates an unsigned raw issuance transaction based on supplied addresses and amounts, and the input outpoint containing policyAsset to spend from (this is needed to generate the asset and token IDs). 

The raw transaction can then be signed directly with signrawtransaction. 