### PR TITLE
policy changes to restrict issuance and allow no fees

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -153,6 +153,7 @@ testScripts = [
     'confidential_transactions.py',
     'unconfidential_transactions.py',
     'asset_stats.py',
+    'raw_issuance.py',
     'preciousblock.py',
     #'p2p-segwit.py',
     #'importprunedfunds.py',

--- a/qa/rpc-tests/raw_issuance.py
+++ b/qa/rpc-tests/raw_issuance.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class RawIssuance (BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 4
+        self.extra_args = [['-issuanceblock'] for i in range(4)]
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(3, self.options.tmpdir, self.extra_args[:3])
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,0,2)
+        self.is_network_split=False
+        self.sync_all()
+
+    def run_test (self):
+
+        # Check that there's 100 UTXOs on each of the nodes
+        assert_equal(len(self.nodes[0].listunspent()), 100)
+        assert_equal(len(self.nodes[1].listunspent()), 100)
+        assert_equal(len(self.nodes[2].listunspent()), 100)
+
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['balance']["CBT"], 21000000)
+
+        print("Mining blocks...")
+        self.nodes[1].generate(101)
+        self.sync_all()
+
+        assert_equal(self.nodes[0].getbalance("", 0, False, "CBT"), 21000000)
+        assert_equal(self.nodes[1].getbalance("", 0, False, "CBT"), 21000000)
+        assert_equal(self.nodes[2].getbalance("", 0, False, "CBT"), 21000000)
+
+        #Set all OP_TRUE genesis outputs to single node
+        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 21000000, "", "", True)
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        assert_equal(self.nodes[0].getbalance("", 0, False, "CBT"), 21000000)
+        assert_equal(self.nodes[1].getbalance("", 0, False, "CBT"), 0)
+        assert_equal(self.nodes[2].getbalance("", 0, False, "CBT"), 0)
+
+        #test creatation of raw multisig issuance transactions                          
+        #get a new address and public and private key for each node                     
+        address_node1 = self.nodes[0].getnewaddress()
+        val_addr_node1 = self.nodes[0].validateaddress(address_node1)
+        privkey_node1 = self.nodes[0].dumpprivkey(address_node1)
+
+        address_node2 =self.nodes[1].getnewaddress()
+        val_addr_node2 = self.nodes[1].validateaddress(address_node2)
+        privkey_node2 =self.nodes[1].dumpprivkey(address_node2)
+
+        address_node3 =self.nodes[2].getnewaddress()
+        val_addr_node3 = self.nodes[2].validateaddress(address_node3)
+        privkey_node3 =self.nodes[2].dumpprivkey(address_node3)
+
+        #create 2 of 3 multisig P2SH script and address                                 
+        multisig = self.nodes[0].createmultisig(2,[val_addr_node1["pubkey"],val_addr_node2["pubkey"],val_addr_node3["pubkey"]])
+        #send some policyasset to the P2SH address
+        pa_txid = self.nodes[0].sendtoaddress(multisig["address"],1)
+        self.nodes[1].generate(1)
+        self.sync_all()
+
+        #get the vout and scriptPubKey of the multisig output                                            
+        vout = 0
+        pa_tx = self.nodes[1].getrawtransaction(pa_txid,1)
+
+        for val in pa_tx["vout"]:
+            for i,j in val.items():
+                if i == "n": vout_t = j
+            for i,j in val.items():
+                if i == "scriptPubKey":
+                    for i2,j2 in j.items():
+                        if i2 == "hex": script_t = j2
+                    for i2,j2 in j.items(): 
+                        if(i2 == "type" and j2 == "scripthash"):
+                            script_pk = script_t
+                            vout = vout_t
+
+        #get address to send tokens and re-issuance tokens  
+        asset_addr = self.nodes[1].getnewaddress()
+        token_addr = self.nodes[2].getnewaddress()
+
+        #create an unsigned raw issuance transaction
+        issuance_tx = self.nodes[1].createrawissuance(asset_addr,10.0,token_addr,1.0,multisig["address"],1.0000,1,pa_txid,str(vout))
+
+        #node1 partially sign transaction
+        partial_signed = self.nodes[0].signrawtransaction(issuance_tx["rawtx"],[{"txid":pa_txid,"vout":vout,"scriptPubKey":script_pk,"redeemScript":multisig["redeemScript"]}],[privkey_node1])
+        assert(not partial_signed["complete"])
+
+        #node1 partially sign transaction 
+        signed_tx = self.nodes[1].signrawtransaction(partial_signed["hex"],[{"txid":pa_txid,"vout":vout,"scriptPubKey":script_pk,"redeemScript":multisig["redeemScript"]}],[privkey_node2])
+
+        assert(signed_tx["complete"])
+        self.nodes[1].generate(2)
+        self.sync_all()
+
+        #submit signed transaction to network
+        submit = self.nodes[1].sendrawtransaction(signed_tx["hex"])
+
+        #confirm transaction accepted by mempool 
+        mempool_tx = self.nodes[1].getrawmempool()
+        assert_equal(mempool_tx[0],submit)
+        self.nodes[1].generate(10)
+        self.sync_all()
+
+        #confirm asset can be spent by node2 wallet
+        asset_addr2 = self.nodes[2].getnewaddress()
+        asset_tx = self.nodes[1].sendtoaddress(asset_addr2,5,' ',' ',False,issuance_tx["asset"],True)
+        mempool1 = self.nodes[1].getrawmempool()
+        assert_equal(mempool1[0],asset_tx)
+        self.nodes[1].generate(2)
+        self.sync_all()
+
+        #create raw issuance transaction with an issued asset as input
+        vout = 0
+        outvalue = 0.0
+        ia_tx = self.nodes[2].getrawtransaction(asset_tx,1)
+
+        for val in ia_tx["vout"]:
+            for i,j in val.items():
+                if i == "n": vout_t = j
+                if i == "value": outvalue = j
+            for i,j in val.items():
+                if i == "scriptPubKey":
+                    for i2,j2 in j.items():
+                        if(i2 == "addresses" and j2[0] == asset_addr2):
+                            vout = vout_t
+
+        dum_addr1 = self.nodes[1].getnewaddress()
+        dum_addr2 = self.nodes[1].getnewaddress()
+
+        #create an unsigned raw issuance transaction
+        issuance_tx2 = self.nodes[2].createrawissuance(dum_addr1,20.0,dum_addr2,2.0,asset_addr2,outvalue,1,asset_tx,str(vout))
+
+        #node2 sign transaction
+        tx_signed = self.nodes[2].signrawtransaction(issuance_tx2["rawtx"])
+        assert(tx_signed["complete"])
+
+        #submit signed transaction to network
+        try:
+            submit = self.nodes[2].sendrawtransaction(tx_signed["hex"])
+        except JSONRPCException as exp:
+            print(exp.error['code'])
+            assert_equal(exp.error['code'], -26) # blocked issuance
+        else:
+            assert(False)
+
+        return
+
+if __name__ == '__main__':
+    RawIssuance().main()

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -195,8 +195,6 @@ class WalletTest (BitcoinTestFramework):
         #submit signed transaction to network
         submit = self.nodes[1].sendrawtransaction(signed_tx["hex"])
 
-        print(submit)
-
         #confirm transaction accepted by mempool 
         mempool_tx = self.nodes[1].getrawmempool()
         assert_equal(mempool_tx[0],submit)

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -179,7 +179,7 @@ class WalletTest (BitcoinTestFramework):
         token_addr = self.nodes[1].getnewaddress()
 
         #create an unsigned raw issuance transaction 
-        issuance_tx = self.nodes[1].createrawissuance(asset_addr,10,token_addr,1,multisig["address"],0.9999,1,0.0001,pa_txid,str(vout))
+        issuance_tx = self.nodes[1].createrawissuance(asset_addr,10.0,token_addr,1.0,multisig["address"],1.0000,1,pa_txid,str(vout))
 
         #node1 partially sign transaction
         partial_signed = self.nodes[0].signrawtransaction(issuance_tx["rawtx"],[{"txid":pa_txid,"vout":vout,"scriptPubKey":script_pk,"redeemScript":multisig["redeemScript"]}],[privkey_node1])
@@ -194,6 +194,8 @@ class WalletTest (BitcoinTestFramework):
 
         #submit signed transaction to network
         submit = self.nodes[1].sendrawtransaction(signed_tx["hex"])
+
+        print(submit)
 
         #confirm transaction accepted by mempool 
         mempool_tx = self.nodes[1].getrawmempool()

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -115,10 +115,14 @@ bool IsWhitelisted(const CTransaction& tx)
     if (!Solver(txout.scriptPubKey, whichType, vSolutions))
       return false;
 
-    //return false if not P2PKH or TX_FEE
-    if(!(whichType == TX_FEE || whichType == TX_PUBKEYHASH)) return false;
-    //skip whitelist check if TX_FEE
+    //skip whitelist check if issuance transaction
+    if(!tx.vin[0].assetIssuance.IsNull()) continue;
+    //skip whitelist check if output is TX_FEE
     if(whichType == TX_FEE) continue;
+    //skip whitelist check if output is OP_RETURN
+    if(whichType == TX_NULL_DATA) continue;    
+    //return false if not P2PKH
+    if(!(whichType == TX_PUBKEYHASH)) return false;
 
     CKeyID keyId;
     keyId = CKeyID(uint160(vSolutions[0]));

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -200,10 +200,14 @@ bool CTransaction::HasValidFee() const
 CAmountMap CTransaction::GetFee() const
 {
     CAmountMap fee;
-    for (unsigned int i = 0; i < vout.size(); i++)
+    unsigned int numFees = 0;
+    for (unsigned int i = 0; i < vout.size(); i++) {
         if (vout[i].IsFee()) {
             fee[vout[i].nAsset.GetAsset()] += vout[i].nValue.GetAmount();
+            numFees++;
         }
+    }
+    if(numFees == 0) fee[vout[0].nAsset.GetAsset()] = 0;
     return fee;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1095,13 +1095,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
       return state.DoS(0, false, REJECT_NONSTANDARD, "non-whitelisted-address");
     }
 
-    // Accept only transactions that have no asset issuance inputs
-    if(fblockissuancetx){
-      if(GetNumIssuances(tx) > 0){
-	return state.DoS(0, false, REJECT_NONSTANDARD, "blocked-asset-issuance-txn");
-      }
-    }
-
     // Only accept nLockTime-using transactions that can be mined in the next
     // block; we don't want our mempool filled up with transactions that can't
     // be mined yet.
@@ -1200,18 +1193,32 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         if (fRequireStandard && !AreInputsStandard(tx, view))
             return state.Invalid(false, REJECT_NONSTANDARD, "bad-txns-nonstandard-inputs");
 
-	// Accept only transactions that spend from scriptSig inputs with pubkeys that are NOT on the freezelist
-// Pubkeys that are on the freezelist AND the burnlist that are sent to OP_RETURN outputs are passed
-	if (fRequireFreezelistCheck){
-	  if(IsFreezelisted(tx,view)){
-	    if(fEnableBurnlistCheck){
-	      if(!IsBurnlisted(tx,view))
-		return state.DoS(0, false, REJECT_NONSTANDARD, "freezelist-no-burnlist-address");
-	    } else {
-	      return state.DoS(0, false, REJECT_NONSTANDARD, "freezelist-address");
+	    // Accept only transactions that spend from scriptSig inputs with pubkeys that are NOT on the freezelist
+        // Pubkeys that are on the freezelist AND the burnlist AND that are sent to OP_RETURN outputs are passed
+	    if (fRequireFreezelistCheck){
+	        if(IsFreezelisted(tx,view)){
+	            if(fEnableBurnlistCheck){
+	                if(!IsBurnlisted(tx,view))
+		               return state.DoS(0, false, REJECT_NONSTANDARD, "freezelist-no-burnlist-address");
+	                } else {
+	            return state.DoS(0, false, REJECT_NONSTANDARD, "freezelist-address");
+	            }
+	        }
 	    }
-	  }
-	}
+
+        // Accept only transactions that are asset issuances if they have a policyAsset input. 
+        if(fblockissuancetx){
+            const CAssetIssuance& issuance = tx.vin[0].assetIssuance;
+            if (!issuance.IsNull() && !issuance.IsReissuance()) {
+                CAsset pAsset(policyAsset);
+                const CTxOut& prev = view.GetOutputFor(tx.vin[0]);
+                CAsset asset;
+                asset = prev.nAsset.GetAsset();
+                if(asset != pAsset) {
+                    return state.DoS(0, false, REJECT_NONSTANDARD, "blocked-asset-issuance-txn");
+                }
+            }
+        }
 
         // Check for non-standard witness in P2WSH
         if (tx.HasWitness() && fRequireStandard && !IsWitnessStandard(tx, view))
@@ -1219,7 +1226,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
 
         int64_t nSigOpsCost = GetTransactionSigOpCost(tx, view, STANDARD_SCRIPT_VERIFY_FLAGS);
 
-        if (!tx.HasValidFee())
+        if (!tx.HasValidFee() && tx.vin[0].assetIssuance.IsNull())
             return state.DoS(0, false, REJECT_INVALID, "bad-fees");
         CAmount nFees = tx.GetFee().begin()->second;
         CAsset feeAsset = tx.GetFee().begin()->first;
@@ -1262,12 +1269,12 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
                 strprintf("%d", nSigOpsCost));
 
         CAmount mempoolRejectFee = pool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFee(nSize);
-        if (mempoolRejectFee > 0 && nModifiedFees < mempoolRejectFee) {
+        if (mempoolRejectFee > 0 && nModifiedFees < mempoolRejectFee && tx.vin[0].assetIssuance.IsNull()) {
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool min fee not met", false, strprintf("%d < %d for asset %s", nFees, mempoolRejectFee, feeAsset.GetHex()));
         }
 
         // No transactions are allowed below minRelayTxFee except from disconnected blocks
-        if (fLimitFree && nModifiedFees < ::minRelayTxFee.GetFee(nSize))
+        if (fLimitFree && nModifiedFees < ::minRelayTxFee.GetFee(nSize) && tx.vin[0].assetIssuance.IsNull())
         {
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "min relay fee not met");
         }
@@ -1931,7 +1938,7 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
         }
 
         // Tally transaction fees
-        if (!tx.HasValidFee()) {
+        if (!tx.HasValidFee() && tx.vin[0].assetIssuance.IsNull()) {
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-outofrange");
         }
         if (fScriptChecks && !VerifyAmounts(inputs, tx, pvChecks, cacheStore)) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1226,7 +1226,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
 
         int64_t nSigOpsCost = GetTransactionSigOpCost(tx, view, STANDARD_SCRIPT_VERIFY_FLAGS);
 
-        if (!tx.HasValidFee() && tx.vin[0].assetIssuance.IsNull())
+        if (!tx.HasValidFee())
             return state.DoS(0, false, REJECT_INVALID, "bad-fees");
         CAmount nFees = tx.GetFee().begin()->second;
         CAsset feeAsset = tx.GetFee().begin()->first;
@@ -1279,7 +1279,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "min relay fee not met");
         }
 
-        if (nAbsurdFee && nFees > nAbsurdFee && tx.vin[0].assetIssuance.IsNull())
+        if (nAbsurdFee && nFees > nAbsurdFee)
             return state.Invalid(false,
                 REJECT_HIGHFEE, "absurdly-high-fee",
                 strprintf("%d > %d for asset %s", nFees, nAbsurdFee, feeAsset.GetHex()));
@@ -1938,7 +1938,7 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
         }
 
         // Tally transaction fees
-        if (!tx.HasValidFee() && tx.vin[0].assetIssuance.IsNull()) {
+        if (!tx.HasValidFee()) {
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-outofrange");
         }
         if (fScriptChecks && !VerifyAmounts(inputs, tx, pvChecks, cacheStore)) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1279,7 +1279,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "min relay fee not met");
         }
 
-        if (nAbsurdFee && nFees > nAbsurdFee)
+        if (nAbsurdFee && nFees > nAbsurdFee && tx.vin[0].assetIssuance.IsNull())
             return state.Invalid(false,
                 REJECT_HIGHFEE, "absurdly-high-fee",
                 strprintf("%d > %d for asset %s", nFees, nAbsurdFee, feeAsset.GetHex()));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3766,7 +3766,7 @@ UniValue claimpegin(const JSONRPCRequest& request)
 
 UniValue createrawissuance(const JSONRPCRequest& request)
 {
-  if (request.fHelp || request.params.size() !=10)
+  if (request.fHelp || request.params.size() !=9)
     throw runtime_error(
             "createrawissuance assetaddress assetamount tokenaddress tokenamount changeaddress feeamount inputtxid vout\n"
             "\nCreate a raw unsigned asset issuance transaction to specified addresses with a policyAsset outpoint as input.\n"
@@ -3778,9 +3778,8 @@ UniValue createrawissuance(const JSONRPCRequest& request)
 	    "5. \"changeaddress\"         (string, required) Address to return the policyAsset input.\n"
 	    "6. \"changeamount\"          (numeric or string, required) Return policyAsset amount.\n"
 	    "7. \"changenum\"             (numeric or string, required) Number of change outputs to be generated\n"
-	    "8. \"feeamount\"             (numeric or string, required) Fee output amount.\n"
-            "9. \"inputtxid\"             (string, required) policyAsset input TXID.\n"
-	    "10. \"vout\"                  (numeric or string, required) policyAsset TXID output index\n"
+            "8. \"inputtxid\"             (string, required) policyAsset input TXID.\n"
+	    "9. \"vout\"                  (numeric or string, required) policyAsset TXID output index\n"
             "\nResult:\n"
             "{                        (json object)\n"
             "  \"rawtx\":\"<rawtx>\",   (string) Hex encoded raw unsigned issuance transaction.\n"
@@ -3789,8 +3788,8 @@ UniValue createrawissuance(const JSONRPCRequest& request)
             "  \"token\":\"<token>\", (string) Token type for issuance.\n"
             "}\n"
             "\nExamples:\n"
-            + HelpExampleCli("createrawissuance", "\"2dhfx249gZKqMGKtKAgceuCyDiHVEeVZWzU\" 100.0 \"2dp5EWgkc4RyzVvBvAyRAMuJ1hS84BgSBLj\" 1.0 \"2djpn7hq9Jh3jx3sjhPXuhUpJQWHrtXrKLr\" 99.9995 1 0.0005 \"42b7101f4596d39cfb5f5e5ca7b6873474607b04f365590f478261ad74dae717\" 1 ")
-            + HelpExampleRpc("createrawissuance", "\"2dhfx249gZKqMGKtKAgceuCyDiHVEeVZWzU\" 100.0 \"2dp5EWgkc4RyzVvBvAyRAMuJ1hS84BgSBLj\" 1.0 \"2djpn7hq9Jh3jx3sjhPXuhUpJQWHrtXrKLr\" 99.9995 1 0.0005 \"42b7101f4596d39cfb5f5e5ca7b6873474607b04f365590f478261ad74dae717\" 1 ")
+            + HelpExampleCli("createrawissuance", "\"2dhfx249gZKqMGKtKAgceuCyDiHVEeVZWzU\" 100.0 \"2dp5EWgkc4RyzVvBvAyRAMuJ1hS84BgSBLj\" 1.0 \"2djpn7hq9Jh3jx3sjhPXuhUpJQWHrtXrKLr\" 10.0 1 \"42b7101f4596d39cfb5f5e5ca7b6873474607b04f365590f478261ad74dae717\" 1 ")
+            + HelpExampleRpc("createrawissuance", "\"2dhfx249gZKqMGKtKAgceuCyDiHVEeVZWzU\" 100.0 \"2dp5EWgkc4RyzVvBvAyRAMuJ1hS84BgSBLj\" 1.0 \"2djpn7hq9Jh3jx3sjhPXuhUpJQWHrtXrKLr\" 10.0 1 \"42b7101f4596d39cfb5f5e5ca7b6873474607b04f365590f478261ad74dae717\" 1 ")
 			);
   //Get the output addresses
   CBitcoinAddress assetAddr(request.params[0].get_str());
@@ -3810,7 +3809,6 @@ UniValue createrawissuance(const JSONRPCRequest& request)
   CAmount nAmount = AmountFromValue(request.params[1]);
   CAmount nTokens = AmountFromValue(request.params[3]);
   CAmount nChange = AmountFromValue(request.params[5]);
-  CAmount nFee = AmountFromValue(request.params[7]);
 
   if (nAmount == 0 && nTokens == 0) {
     throw JSONRPCError(RPC_TYPE_ERROR, "Issuance must have one non-zero component");
@@ -3823,8 +3821,8 @@ UniValue createrawissuance(const JSONRPCRequest& request)
 
   //get the input outpoint from RPC
   uint256 prevtxhash;
-  prevtxhash.SetHex(request.params[8].get_str());
-  uint32_t nout = atoi(request.params[9].get_str());
+  prevtxhash.SetHex(request.params[7].get_str());
+  uint32_t nout = atoi(request.params[8].get_str());
   COutPoint policyOutpoint(prevtxhash,nout);
 
   CMutableTransaction rawTx;
@@ -3848,8 +3846,6 @@ UniValue createrawissuance(const JSONRPCRequest& request)
   for(int it=0;it<nChangeOutputs;it++) {
     rawTx.vout.push_back(txoutChange);
   }
-  CTxOut out(pAsset, nFee, CScript());
-  rawTx.vout.push_back(out);
 
   //standard sequence number
   uint32_t nSequence = (rawTx.nLockTime ? std::numeric_limits<uint32_t>::max() - 1 : std::numeric_limits<uint32_t>::max());


### PR DESCRIPTION
With -issuanceblock enabled, policy is now to accept new issuance transactions only if the single input is of the type policyAsset. New QA test to test that policyAsset issuances pass and issued asset input issuances are blocked. 

Issuance transactions are accepted as policy with no fee outputs. 

createrawissuance RPC modified to create issuances with no fee output

Address whitelist policy check allows through issuance transactions