### PR TITLE
burn asset rpc and fee execption

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -102,6 +102,22 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
     return true;
 }
 
+bool IsBurn(const CTransaction& tx)
+{
+  //function that determines if all outputs of a transaction are OP_RETURN
+  txnouttype whichType;
+
+  BOOST_FOREACH(const CTxOut& txout, tx.vout) {
+
+    std::vector<std::vector<unsigned char> > vSolutions;
+    if (!Solver(txout.scriptPubKey, whichType, vSolutions))
+      return false;
+
+    if(whichType != TX_NULL_DATA) return false;
+  }
+  return true;
+}
+
 bool IsWhitelisted(const CTransaction& tx)
 {
   //function that determines that all outputs of a transaction are P2PKH
@@ -193,14 +209,14 @@ bool IsBurnlisted(const CTransaction& tx, const CCoinsViewCache& mapInputs)
   }
 
   if(nin > 0) {
-    //are ALL outputs OP_RETURN burn outputs or fee outputs
+    //are ALL outputs OP_RETURN burn outputs
     BOOST_FOREACH(const CTxOut& txout, tx.vout) {
       
       std::vector<std::vector<unsigned char> > vSolutions;
       txnouttype whichType;
       if (!Solver(txout.scriptPubKey, whichType, vSolutions)) return false;
 
-      if(!(whichType == TX_NULL_DATA || whichType == TX_FEE || txout.nAsset.GetAsset() == policyAsset)) return false;
+      if(!(whichType == TX_NULL_DATA || txout.nAsset.GetAsset() == policyAsset)) return false;
     }
   } else {
     return false;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -85,6 +85,11 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
 bool IsStandardTx(const CTransaction& tx, std::string& reason);
 
     /**
+     * Check if all a transactions outputs are OP_RETURN
+     */
+bool IsBurn(const CTransaction& tx);
+
+    /**
      * Check all type and whitelist status of outputs of tx
      * Return true if all outputs of tx are type TX_PUBKEYHASH and all PUBKEYHASHes are present in the whitelist database 
      */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1269,12 +1269,12 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
                 strprintf("%d", nSigOpsCost));
 
         CAmount mempoolRejectFee = pool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFee(nSize);
-        if (mempoolRejectFee > 0 && nModifiedFees < mempoolRejectFee && tx.vin[0].assetIssuance.IsNull()) {
+        if (mempoolRejectFee > 0 && nModifiedFees < mempoolRejectFee && tx.vin[0].assetIssuance.IsNull() && !IsBurn(tx)) {
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool min fee not met", false, strprintf("%d < %d for asset %s", nFees, mempoolRejectFee, feeAsset.GetHex()));
         }
 
         // No transactions are allowed below minRelayTxFee except from disconnected blocks
-        if (fLimitFree && nModifiedFees < ::minRelayTxFee.GetFee(nSize) && tx.vin[0].assetIssuance.IsNull())
+        if (fLimitFree && nModifiedFees < ::minRelayTxFee.GetFee(nSize) && tx.vin[0].assetIssuance.IsNull() && !IsBurn(tx))
         {
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "min relay fee not met");
         }


### PR DESCRIPTION
A new RPC to create raw transactions sending a single input to a null (OP_RETURN) output. 

The burning of tokens should not require a transaction fee, so a new exception is added to the mempool acceptance fee check. 