### PR TITLE
added testmempoolaccept RPC

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -155,6 +155,7 @@ testScripts = [
     'unconfidential_transactions.py',
     'asset_stats.py',
     'raw_issuance.py',
+    'mempool_accept.py',
     'preciousblock.py',
     #'p2p-segwit.py',
     #'importprunedfunds.py',

--- a/qa/rpc-tests/mempool_accept.py
+++ b/qa/rpc-tests/mempool_accept.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test re-org scenarios with a mempool that contains transactions
+# that spend (directly or indirectly) coinbase transactions.
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class MempoolAcceptanceTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir)
+        connect_nodes_bi(self.nodes,0,1)
+        self.is_network_split=False
+        self.sync_all()
+
+    def run_test (self):
+
+        # Check that there's 100 UTXOs on each of the nodes                                             
+        assert_equal(len(self.nodes[0].listunspent()), 100)
+        assert_equal(len(self.nodes[1].listunspent()), 100)
+
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['balance']["CBT"], 21000000)
+
+        print("Mining blocks...")
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        assert_equal(self.nodes[0].getbalance("", 0, False, "CBT"), 21000000)
+        assert_equal(self.nodes[1].getbalance("", 0, False, "CBT"), 21000000)
+
+        address_node1 = self.nodes[0].getnewaddress()
+
+        pa_txid = self.nodes[0].sendtoaddress(address_node1,1)
+        self.nodes[1].generate(1)
+        self.sync_all()
+
+        #get the raw transaction
+        rawtx = self.nodes[0].getrawtransaction(pa_txid)
+
+        #check if we can send the transaction again (once it is in the mempool)
+        result_test = self.nodes[0].testmempoolaccept(rawtx)
+
+        assert_equal(result_test["reject-reason"],"257: txn-already-in-mempool")
+
+        #confirm it
+        self.nodes[0].generate(10)
+        self.sync_all()
+
+        #check if we can send it again
+        result_test = self.nodes[0].testmempoolaccept(rawtx)
+
+        assert_equal(result_test["reject-reason"],"257: txn-already-known")
+
+        dectx = self.nodes[0].decoderawtransaction(rawtx)
+
+        #try to spend the output again
+        txin = dectx["vin"][0]["txid"]
+        vout = dectx["vin"][0]["vout"]
+
+        value = 0
+        for oput in dectx["vout"]:
+            value += oput["value"]
+
+        input1 = {}
+        input1["txid"] = txin
+        input1["vout"] = vout
+
+        inputs = []
+        inputs.append(input1)
+
+        address2 = self.nodes[0].getnewaddress()
+
+        outputs = {}
+        outputs[address2] = value
+
+        newtx = self.nodes[0].createrawtransaction(inputs,outputs)
+        signednewtx = self.nodes[0].signrawtransaction(newtx)
+        result_test = self.nodes[0].testmempoolaccept(signednewtx["hex"])
+
+        assert_equal(result_test["reject-reason"],"18: bad-txns-inputs-spent")
+
+
+if __name__ == '__main__':
+    MempoolAcceptanceTest().main()

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1461,6 +1461,74 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
     return result;
 }
 
+UniValue testmempoolaccept(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 2) {
+        throw std::runtime_error(
+            // clang-format off
+            "testmempoolaccept [\"rawtxs\"] ( allowhighfees )\n"
+            "\nReturns if raw transaction (serialized, hex-encoded) would be accepted by mempool.\n"
+            "\nThis checks if the transaction violates the consensus or policy rules.\n"
+            "\nSee sendrawtransaction call.\n"
+            "\nArguments:\n"
+            "1. rawtxs           (string, required) Hex strings of raw transactions.\n"
+            "2. allowhighfees    (boolean, optional, default=false) Allow high fees\n"
+            "\nResult:\n"
+            "[                   (array) The result of the mempool acceptance test for each raw transaction in the input array.\n"
+            "                            Length is exactly one for now.\n"
+            " {\n"
+            "  \"txid\"           (string) The transaction hash in hex\n"
+            "  \"allowed\"        (boolean) If the mempool allows this tx to be inserted\n"
+            "  \"reject-reason\"  (string) Rejection string (only present when 'allowed' is false)\n"
+            " }\n"
+            "]\n"
+            "\nExamples:\n"
+            "\nTest acceptance of the transaction (signed hex)\n"
+            + HelpExampleCli("testmempoolaccept", "signedhex") +
+            "\nAs a json rpc call\n"
+            + HelpExampleRpc("testmempoolaccept", "signedhex")
+            // clang-format on
+            );
+    }
+
+    CMutableTransaction mtx;
+    if (!DecodeHexTx(mtx, request.params[0].get_str())) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
+    }
+    CTransactionRef tx(MakeTransactionRef(std::move(mtx)));
+    const uint256& tx_hash = tx->GetHash();
+
+    CAmount max_raw_tx_fee = ::maxTxFee;
+    if (!request.params[1].isNull() && request.params[1].get_bool()) {
+        max_raw_tx_fee = 0;
+    }
+
+    UniValue result_0(UniValue::VOBJ);
+    result_0.pushKV("txid", tx_hash.GetHex());
+
+    CValidationState state;
+    bool missing_inputs;
+    bool test_accept_res;
+    bool fLimitFree = false;
+    {
+        LOCK(cs_main);
+        test_accept_res = AcceptToMemoryPool(mempool, state, std::move(tx), fLimitFree, &missing_inputs,
+            nullptr /* plTxnReplaced */, false /* bypass_limits */, max_raw_tx_fee, /* test_accpet */ true);
+    }
+    result_0.pushKV("allowed", test_accept_res);
+    if (!test_accept_res) {
+        if (state.IsInvalid()) {
+            result_0.pushKV("reject-reason", strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));
+        } else if (missing_inputs) {
+            result_0.pushKV("reject-reason", "missing-inputs");
+        } else {
+            result_0.pushKV("reject-reason", state.GetRejectReason());
+        }
+    }
+
+    return result_0;
+}
+
 UniValue sendrawtransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 3)
@@ -1554,6 +1622,7 @@ static const CRPCCommand commands[] =
     { "rawtransactions",    "decodescript",           &decodescript,           true,  {"hexstring"} },
     { "rawtransactions",    "sendrawtransaction",     &sendrawtransaction,     false, {"hexstring","allowhighfees"} },
     { "rawtransactions",    "signrawtransaction",     &signrawtransaction,     false, {"hexstring","prevtxs","privkeys","sighashtype"} }, /* uses wallet if enabled */
+    { "rawtransactions",    "testmempoolaccept",      &testmempoolaccept,      false, {"hexstring","allowhighfees"} },
     { "rawtransactions",    "rawblindrawtransaction", &rawblindrawtransaction, false, {}},
 #ifdef ENABLE_WALLET
     { "rawtransactions",    "blindrawtransaction",    &blindrawtransaction,    true, {}},

--- a/src/validation.h
+++ b/src/validation.h
@@ -345,12 +345,12 @@ void PruneBlockFilesManual(int nPruneUpToHeight);
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
                         bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced = NULL,
-                        bool fOverrideMempoolLimit=false, const CAmount nAbsurdFee=0);
+                        bool fOverrideMempoolLimit=false, const CAmount nAbsurdFee=0, bool test_accept=false);
 
 /** (try to) add transaction to memory pool with a specified acceptance time **/
 bool AcceptToMemoryPoolWithTime(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
                         bool* pfMissingInputs, int64_t nAcceptTime, std::list<CTransactionRef>* plTxnReplaced = NULL,
-                        bool fOverrideMempoolLimit=false, const CAmount nAbsurdFee=0);
+                        bool fOverrideMempoolLimit=false, const CAmount nAbsurdFee=0, bool test_accept=false);
 
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);


### PR DESCRIPTION
New RPC call to enable the validity of raw transactions to determined (i.e. they have valid inputs/signatures etc) without actually sending the tx to the mempool. 

Is based on the testmempoolaccept RPC added to Bitcoin 0.17 but not in Elements yet. 