### PR TITLE
Freezetrack

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -501,6 +501,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-embedcontract", _("Embed contract in the block header and address derivation"));
     strUsage += HelpMessageOpt("-embedmapping", _("Embed asset mapping object in the block header"));
     strUsage += HelpMessageOpt("-issuecontrolscript", _("Embed the issuance controller script in the genesis block"));
+    strUsage += HelpMessageOpt("-recordinflation", _("Record issuance data and freeze history"));
 
     strUsage += HelpMessageGroup(_("RPC server options:"));
     strUsage += HelpMessageOpt("-server", _("Accept command line and JSON-RPC commands"));
@@ -1107,6 +1108,8 @@ bool AppInitParameterInteraction()
     //Acceptance of OP_REGISTERADDRESS 
     fAcceptRegisteraddress = GetBoolArg("-registeraddress", DEFAULT_ACCEPT_REGISTERADDRESS);
     nMaxRegisteraddressBytes = GetArg("-registeraddresssize", nMaxRegisteraddressBytes);
+
+    fRecordInflation = GetBoolArg("-recordinflation", DEFAULT_PERMIT_BAREMULTISIG);
 
     // Option to startup with mocktime set (used for regression testing):
     SetMockTime(GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1109,7 +1109,7 @@ bool AppInitParameterInteraction()
     fAcceptRegisteraddress = GetBoolArg("-registeraddress", DEFAULT_ACCEPT_REGISTERADDRESS);
     nMaxRegisteraddressBytes = GetArg("-registeraddresssize", nMaxRegisteraddressBytes);
 
-    fRecordInflation = GetBoolArg("-recordinflation", DEFAULT_PERMIT_BAREMULTISIG);
+    fRecordInflation = GetBoolArg("-recordinflation", DEFAULT_RECORD_INFLATION);
 
     // Option to startup with mocktime set (used for regression testing):
     SetMockTime(GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -7,6 +7,7 @@
 
 #include "policy/policy.h"
 #include "validation.h"
+#include "issuance.h"
 
 using namespace std;
 
@@ -402,6 +403,74 @@ bool UpdateBurnList(const CTransaction& tx, const CCoinsViewCache& mapInputs)
         }
     }
     return true;
+}
+
+bool UpdateAssetMap(const CTransaction& tx)
+{
+    if(!tx.vin[0].assetIssuance.IsNull()){
+        if(!tx.vin[0].assetIssuance.IsReissuance()) {
+            IssuanceData newIssuance;
+
+            uint256 entropy;
+            GenerateAssetEntropy(entropy, tx.vin[0].prevout, tx.vin[0].assetIssuance.assetEntropy);
+            newIssuance.entropy = entropy;
+
+            CAsset asset;
+            CalculateAsset(asset, entropy);
+            CAsset token;
+            CalculateReissuanceToken(token, entropy, false);
+            newIssuance.token = token.id;
+            newIssuance.asset = asset;
+
+            assetEntropyMap.push_back(newIssuance);
+        }
+    }
+  return true;
+}
+
+void UpdateFreezeHistory(const CTransaction& tx)
+{
+    //is the transaction a redemption transaction
+    txnouttype whichType;
+    bool isfrz = false;
+    for (uint32_t itr = 0; itr < tx.vout.size(); ++itr) {
+        vector<vector<uint8_t>> vSolutions;
+        if (Solver(tx.vout[itr].scriptPubKey, whichType, vSolutions)) {
+            if (whichType == TX_PUBKEYHASH && uint160(vSolutions[0]).IsNull()) isfrz = true;
+        }
+    }
+    //if a redemption/freeze transaction then add outputs to the history list
+    uint256 txhash = tx.GetHash();
+    if(isfrz) {
+        FreezeHist histEntry;
+        for (uint32_t itr = 0; itr < tx.vout.size(); ++itr) {
+            vector<vector<uint8_t>> vSolutions;
+            if (Solver(tx.vout[itr].scriptPubKey, whichType, vSolutions)) {
+                if (whichType == TX_PUBKEYHASH && !uint160(vSolutions[0]).IsNull()) {
+                    histEntry.txid = txhash;
+                    histEntry.vout = itr;
+                    histEntry.asset = tx.vout[itr].nAsset.GetAsset();
+                    histEntry.freezeheight = chainActive.Height();
+                    histEntry.spendheight = 0;
+                    freezeHistList.push_back(histEntry);
+                }
+            }
+        }
+    // else check if any inputs txids are already on the history list
+    } else {
+        //loop over tx inputs
+        for (uint32_t itr = 0; itr < tx.vin.size(); ++itr) {
+            //for each input, check if the outpoint is in the history list
+            for (uint32_t itr2 = 0; itr2 < freezeHistList.size(); ++itr2) {
+                if(tx.vin[itr].prevout.n == freezeHistList[itr2].vout && tx.vin[itr].prevout.hash == freezeHistList[itr].txid) {
+                    //if not burn, add spend-height
+                    if(!IsBurn(tx)) {
+                        freezeHistList[itr2].spendheight = chainActive.Height();
+                    }
+                }
+            }
+        }
+    }
 }
 
 bool LoadFreezeList(CCoinsView *view)

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -155,14 +155,12 @@ bool LoadFreezeList(CCoinsView *view);
     //function to scane the UTXO set for burnlist addresses
 bool LoadBurnList(CCoinsView *view);
 
-    /**
-    */
+    //function to add new issuance data (token and entropy) to the asset map
+bool UpdateAssetMap(const CTransaction& tx);
 
-    //function to scan the UTXO set for freezelist addresses
-bool LoadFreezeList(CCoinsView *view);
+    //function to track the history of frozen outputs
+bool UpdateFreezeHistory(const CTransaction& tx);
 
-    //function to scane the UTXO set for burnlist addresses
-bool LoadBurnList(CCoinsView *view);
 bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
     /**
      * Check if the transaction is over standard P2WSH resources limit:

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -159,7 +159,7 @@ bool LoadBurnList(CCoinsView *view);
 bool UpdateAssetMap(const CTransaction& tx);
 
     //function to track the history of frozen outputs
-bool UpdateFreezeHistory(const CTransaction& tx);
+void UpdateFreezeHistory(const CTransaction& tx, uint32_t bheight);
 
 bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
     /**

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1032,18 +1032,73 @@ UniValue getutxoassetinfo(const JSONRPCRequest& request)
     std::map<CAsset,CAssetStats> stats;
     if (GetAssetStats(pcoinsTip, stats)) {
         for(auto const& asset : stats){
-	    UniValue item(UniValue::VOBJ);
-	    item.push_back(Pair("asset",asset.first.GetHex()));
-	    item.push_back(Pair("spendabletxouts",asset.second.nSpendableOutputs));
-	    item.push_back(Pair("amountspendable",ValueFromAmount(asset.second.nSpendableAmount)));
-	    item.push_back(Pair("frozentxouts",asset.second.nFrozenOutputs));
-	    item.push_back(Pair("amountfrozen",ValueFromAmount(asset.second.nFrozenAmount)));
-	    ret.push_back(item);
-	}
+    	    UniValue item(UniValue::VOBJ);
+    	    item.push_back(Pair("asset",asset.first.GetHex()));
+    	    item.push_back(Pair("spendabletxouts",asset.second.nSpendableOutputs));
+    	    item.push_back(Pair("amountspendable",ValueFromAmount(asset.second.nSpendableAmount)));
+    	    item.push_back(Pair("frozentxouts",asset.second.nFrozenOutputs));
+    	    item.push_back(Pair("amountfrozen",ValueFromAmount(asset.second.nFrozenAmount)));
+            //add entropy and token mappings
+            if(fRecordInflation) {
+                bool fd = false;
+                for(uint32_t itr = 0; itr < assetEntropyMap.size(); ++itr) {
+                    if(assetEntropyMap[itr].asset == asset.first) {
+                        item.push_back(Pair("entropy",assetEntropyMap[itr].entropy.GetHex()));
+                        item.push_back(Pair("token",assetEntropyMap[itr].token.GetHex()));
+                        fd = true;
+                        break;
+                    }
+                }
+                if(!fd) {
+                    item.push_back(Pair("entropy","null"));
+                    item.push_back(Pair("token","null"));
+                    item.push_back(Pair("size",std::to_string(assetEntropyMap.size())));
+                }
+            }
+    	    ret.push_back(item);
+    	}
     } else {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to read UTXO set");
     }
     return ret;
+}
+
+UniValue getfreezehistory(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 1)
+        throw runtime_error(
+            "getfreezehistory height\n"
+            "Returns an array conatining the history of frozen (redemption) transactions\n"
+            "It returns all outputs that have been unfrozen in the last height blocks\n"
+            "If height is zero it returns all frozen outputs\n"
+            "\nResult:\n"
+            "[\n"
+            "   {\n"
+            "       \"txid\": \"xxxx\",        (string) transaction ID of the redemption transaction\n"
+            "       \"blocks\": xxxxxx,         (numeric) the current number of blocks processed in the server\n"
+            "   }\n"
+            "]\n"
+            "\nExamples:\n"
+            + HelpExampleCli("getblockchaininfo", "0")
+            + HelpExampleRpc("getblockchaininfo", "0")
+        );
+
+    uint32_t nHeight = request.params[0].get_int();
+
+    UniValue ar(UniValue::VARR);
+    uint32_t bh = chainActive.Height();
+    for (uint32_t itr = 0; itr < freezeHistList.size(); ++itr) {
+        if(freezeHistList[itr].spendheight > bh - nHeight || nHeight == 0) {
+            UniValue obj(UniValue::VOBJ);
+            obj.push_back(Pair("txid",freezeHistList[itr].txid.GetHex()));
+            obj.push_back(Pair("vout",(int)freezeHistList[itr].vout));
+            obj.push_back(Pair("asset",freezeHistList[itr].asset.GetHex()));
+            obj.push_back(Pair("start",(int)freezeHistList[itr].freezeheight));
+            obj.push_back(Pair("end",(int)freezeHistList[itr].spendheight));
+            ar.push_back(obj);
+        }
+    }
+    return ar;
 }
 
 UniValue gettxout(const JSONRPCRequest& request)
@@ -2332,6 +2387,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "gettxout",               &gettxout,               true,  {"txid","n","include_mempool"} },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true,  {} },
     { "blockchain",         "getutxoassetinfo",       &getutxoassetinfo,       true,  {} },
+    { "blockchain",         "getfreezehistory",       &getfreezehistory,       true,  {} },
     { "blockchain",         "pruneblockchain",        &pruneblockchain,        true,  {"height"} },
     { "blockchain",         "verifychain",            &verifychain,            true,  {"checklevel","nblocks"} },
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1052,7 +1052,6 @@ UniValue getutxoassetinfo(const JSONRPCRequest& request)
                 if(!fd) {
                     item.push_back(Pair("entropy","null"));
                     item.push_back(Pair("token","null"));
-                    item.push_back(Pair("size",std::to_string(assetEntropyMap.size())));
                 }
             }
     	    ret.push_back(item);
@@ -1065,7 +1064,7 @@ UniValue getutxoassetinfo(const JSONRPCRequest& request)
 
 UniValue getfreezehistory(const JSONRPCRequest& request)
 {
-    if (request.fHelp || request.params.size() != 1)
+    if (request.fHelp || request.params.size() != 0)
         throw runtime_error(
             "getfreezehistory height\n"
             "Returns an array conatining the history of frozen (redemption) transactions\n"
@@ -1083,7 +1082,9 @@ UniValue getfreezehistory(const JSONRPCRequest& request)
             + HelpExampleRpc("getblockchaininfo", "0")
         );
 
-    uint32_t nHeight = request.params[0].get_int();
+//    uint32_t nHeight = request.params[0].get_int();
+
+    uint32_t nHeight = 0;
 
     UniValue ar(UniValue::VARR);
     uint32_t bh = chainActive.Height();
@@ -1093,6 +1094,7 @@ UniValue getfreezehistory(const JSONRPCRequest& request)
             obj.push_back(Pair("txid",freezeHistList[itr].txid.GetHex()));
             obj.push_back(Pair("vout",(int)freezeHistList[itr].vout));
             obj.push_back(Pair("asset",freezeHistList[itr].asset.GetHex()));
+            obj.push_back(Pair("value",ValueFromAmount(freezeHistList[itr].value)));
             obj.push_back(Pair("start",(int)freezeHistList[itr].freezeheight));
             obj.push_back(Pair("end",(int)freezeHistList[itr].spendheight));
             ar.push_back(obj);
@@ -2387,7 +2389,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "gettxout",               &gettxout,               true,  {"txid","n","include_mempool"} },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true,  {} },
     { "blockchain",         "getutxoassetinfo",       &getutxoassetinfo,       true,  {} },
-    { "blockchain",         "getfreezehistory",       &getfreezehistory,       true,  {} },
+    { "blockchain",         "getfreezehistory",       &getfreezehistory,       true,  {"height"} },
     { "blockchain",         "pruneblockchain",        &pruneblockchain,        true,  {"height"} },
     { "blockchain",         "verifychain",            &verifychain,            true,  {"checklevel","nblocks"} },
 

--- a/src/test/blind_tests.cpp
+++ b/src/test/blind_tests.cpp
@@ -364,10 +364,6 @@ BOOST_AUTO_TEST_CASE(naive_blinding_test)
         BOOST_CHECK(BlindTransaction(input_blinds, input_asset_blinds, input_assets, input_amounts, output_blinds, output_asset_blinds, output_pubkeys, vDummy, vDummy, txtemp) == 4);
         BOOST_CHECK(VerifyAmounts(cache, txtemp));
 
-        // Transaction may not have spendable 0-value output
-        txtemp.vout.push_back(CTxOut(CAsset(), 0, CScript() << OP_TRUE));
-        BOOST_CHECK(!VerifyAmounts(cache, txtemp));
-
         // Create imbalance by removing fees, should still be able to blind
         txtemp = tx5;
         txtemp.vout.resize(5);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -71,6 +71,8 @@ CChain chainActive;
 CBlockIndex *pindexBestHeader = NULL;
 CWaitableCriticalSection csBestBlock;
 CConditionVariable cvBlockChange;
+std::vector<IssuanceData> assetEntropyMap;
+std::vector<FreezeHist> freezeHistList;
 int nScriptCheckThreads = 0;
 std::atomic_bool fImporting(false);
 bool fReindex = false;
@@ -84,6 +86,7 @@ bool fScanWhitelist = DEFAULT_SCAN_WHITELIST;
 bool fEnableBurnlistCheck = DEFAULT_BURNLIST_CHECK;
 bool fRequireFreezelistCheck = DEFAULT_BURNLIST_CHECK;
 bool fblockissuancetx = DEFAULT_BLOCK_ISSUANCE;
+bool fRecordInflation = DEFAULT_RECORD_INFLATION;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
 size_t nCoinCacheUsage = 5000 * 300;
@@ -2805,8 +2808,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 addressWhitelist.RegisterAddress(tx, view);
             }
         }
-        
 
+        if(fRecordInflation) {
+            UpdateAssetMap(tx);
+            UpdateFreezeHistory(tx);
+        }
+        
         // GetTransactionSigOpCost counts 3 types of sigops:
         // * legacy (always)
         // * p2sh (when P2SH enabled in flags and excludes coinbase)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2811,7 +2811,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
         if(fRecordInflation) {
             UpdateAssetMap(tx);
-            UpdateFreezeHistory(tx);
+            UpdateFreezeHistory(tx,chainActive.Height()+1);
         }
         
         // GetTransactionSigOpCost counts 3 types of sigops:

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -939,8 +939,8 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
                 if (tx.vout[i].scriptPubKey.IsUnspendable()) {
                     continue;
                 } else {
-                    // No spendable 0-value outputs
-                    return false;
+                    // allow zero value outputs
+                    continue;
                 }
             }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -183,6 +183,11 @@ struct FreezeHist
 	uint32_t vout;
 	uint32_t freezeheight;
 	uint32_t spendheight;
+	CAmount value;
+	bool operator==(const FreezeHist& p) const
+	{
+		return txid == p.txid && vout == p.vout;
+	}
 };
 
 // list of issued asset IDs to tokens and entropy

--- a/src/validation.h
+++ b/src/validation.h
@@ -139,6 +139,7 @@ static const bool DEFAULT_SCAN_WHITELIST = false;
 static const bool DEFAULT_BLOCK_ISSUANCE = false;
 static const bool DEFAULT_BURNLIST_CHECK = false;
 static const bool DEFAULT_FREEZELIST_CHECK = false;
+static const bool DEFAULT_RECORD_INFLATION = false;
 
 /** Default for -permitbaremultisig */
 static const bool DEFAULT_PERMIT_BAREMULTISIG = true;
@@ -168,6 +169,27 @@ extern CPolicyList addressFreezelist;
 //burnlist address list
 extern CPolicyList addressBurnlist;
 
+struct IssuanceData
+{
+	CAsset asset;
+	uint256 token;
+	uint256 entropy;
+};
+
+struct FreezeHist
+{
+	CAsset asset;
+	uint256 txid;
+	uint32_t vout;
+	uint32_t freezeheight;
+	uint32_t spendheight;
+};
+
+// list of issued asset IDs to tokens and entropy
+extern std::vector<IssuanceData> assetEntropyMap;
+// freeze history
+extern std::vector<FreezeHist> freezeHistList;
+
 extern CScript COINBASE_FLAGS;
 extern CCriticalSection cs_main;
 extern CTxMemPool mempool;
@@ -189,6 +211,7 @@ extern bool fScanWhitelist;
 extern bool fRequireFreezelistCheck;
 extern bool fEnableBurnlistCheck;
 extern bool fblockissuancetx;
+extern bool fRecordInflation;
 extern bool fRequireStandard;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1631,6 +1631,10 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool f
                     if(fRequireWhitelistCheck || fScanWhitelist){
                         addressWhitelist.RegisterAddress(*block.vtx[posInBlock], pindex);
                     }
+                    if(fRecordInflation){
+                        UpdateAssetMap(*block.vtx[posInBlock]);
+                        UpdateFreezeHistory(*block.vtx[posInBlock]);
+                    }
                     AddToWalletIfInvolvingMe(*block.vtx[posInBlock], pindex, posInBlock, fUpdate);
                 }
                 if (!ret) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1633,7 +1633,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool f
                     }
                     if(fRecordInflation){
                         UpdateAssetMap(*block.vtx[posInBlock]);
-                        UpdateFreezeHistory(*block.vtx[posInBlock]);
+                        UpdateFreezeHistory(*block.vtx[posInBlock],pindex->nHeight);
                     }
                     AddToWalletIfInvolvingMe(*block.vtx[posInBlock], pindex, posInBlock, fUpdate);
                 }


### PR DESCRIPTION
Two new in-memory lists added to enable the automatic reissuance (inflation) of assets: assetEntropyMap and freezeHistMap. 

assetEntropyMap stores the entropy and reissuance token for each asset. This list is updated each time a new asset is issued. These values are required to create a raw reissuance transaction (for the original reissueasset RPC, these are found from the issuing wallet, however for a multisig reissuance there is no way to determine them from the asset ID alone). 

freezeHistMap keeps a list of outputs that are tagged as frozen (and the blockheight when they are confirmed) and then records if these outputs are spent (and the spending tx block height). This is required to pause and backdate inflation payments if a redemption is canceled/failed. 

The assetEntropyMap is then used to add the entropy and token information to the asset list output from the getutxoassetinfo RPC. The freezeHistMap is read via a new getfreezehistory RPC. 

Also, a change is VerifyAmounts to allow zero value outputs (so that the freeze-tag output can be zero valued). 