### PR TITLE
Fix crash bug with duplicate inputs within a transaction

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3757,7 +3757,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Check transactions
     for (const auto& tx : block.vtx)
-        if (!CheckTransaction(*tx, state, false))
+        if (!CheckTransaction(*tx, state, true))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 


### PR DESCRIPTION
Looking through the source and spotted the fix for CVE-2018-17144 was not applied, the issue is outlined in the link below.

https://bitcoincore.org/en/2018/09/20/notice/

Direct link for upstream commit cherry-picked.

https://github.com/bitcoin/bitcoin/commit/52965fbaef4b8ff310e01273817fb027389d3f80