### PR TITLE
Guardnode: CLTV multisig transaction Solver/Signing and Request changes

### DIFF
--- a/qa/rpc-tests/requests.py
+++ b/qa/rpc-tests/requests.py
@@ -87,6 +87,7 @@ class RequestsTest(BitcoinTestFramework):
 
     # test get request method with/without genesis hash parameter
     requests = self.nodes[0].getrequests()
+    assert_equal(2, len(self.nodes[1].getrequests()))
     assert_equal(2, len(requests))
     for req in requests:
         if txid == req['txid']:
@@ -101,6 +102,7 @@ class RequestsTest(BitcoinTestFramework):
         else:
             assert(False)
     requests = self.nodes[0].getrequests(genesis)
+    assert_equal(self.nodes[1].getrequests(genesis), requests)
     assert_equal(1, len(requests))
     for req in requests:
         if txid == req['txid']:
@@ -113,6 +115,7 @@ class RequestsTest(BitcoinTestFramework):
         else:
             assert(False)
     requests = self.nodes[0].getrequests(genesis2)
+    assert_equal(self.nodes[1].getrequests(genesis2), requests)
     assert_equal(1, len(requests))
     for req in requests:
         if txid2 == req['txid']:
@@ -125,6 +128,7 @@ class RequestsTest(BitcoinTestFramework):
         else:
             assert(False)
     requests = self.nodes[0].getrequests("123450e138b1014173844ee0e4d557ff8a2463b14fcaeab18f6a63aa7c7e1d05")
+    assert_equal(self.nodes[1].getrequests("123450e138b1014173844ee0e4d557ff8a2463b14fcaeab18f6a63aa7c7e1d05"), [])
     assert_equal(requests, [])
 
     # try send spend transaction
@@ -139,6 +143,7 @@ class RequestsTest(BitcoinTestFramework):
     # make request 1 inactive
     self.nodes[0].generate(10)
     requests = self.nodes[0].getrequests()
+    assert_equal(requests, len(self.nodes[1].getrequests()))
     assert_equal(1, len(requests))
     for req in requests:
         if txid2 == req['txid']:
@@ -151,6 +156,7 @@ class RequestsTest(BitcoinTestFramework):
         else:
             assert(False)
     requests = self.nodes[0].getrequests(genesis2)
+    assert_equal(self.nodes[1].getrequests(genesis2), requests)
     assert_equal(1, len(requests))
     for req in requests:
         if txid2 == req['txid']:
@@ -183,6 +189,7 @@ class RequestsTest(BitcoinTestFramework):
     self.sync_all()
 
     assert_equal([], self.nodes[0].getrequests())
+    assert_equal([], self.nodes[1].getrequests())
     assert(self.nodes[1].getbalance()["PERMISSION"] == 1000)
 
     # send second transaction

--- a/qa/rpc-tests/requests.py
+++ b/qa/rpc-tests/requests.py
@@ -2,9 +2,9 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-# Test for the guardnode system
+# Test for the request covalence system
 # TODO: add more tests as work on this progresses
-class GuardnodeTest(BitcoinTestFramework):
+class RequestsTest(BitcoinTestFramework):
   def __init__(self):
     super().__init__()
     self.setup_clean_chain = True
@@ -12,6 +12,7 @@ class GuardnodeTest(BitcoinTestFramework):
     self.extra_args = [["-txindex=1 -initialfreecoins=50000000000000",
     "-permissioncoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac",
     "-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac"] for i in range(2)]
+    self.extra_args[1].append("-requestlist=1")
 
   def setup_network(self, split=False):
     self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
@@ -196,4 +197,4 @@ class GuardnodeTest(BitcoinTestFramework):
     return
 
 if __name__ == '__main__':
-  GuardnodeTest().main()
+  RequestsTest().main()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -128,6 +128,7 @@ BITCOIN_CORE_H = \
   pow.h \
   protocol.h \
   random.h \
+  request.h \
   reverselock.h \
   rpc/client.h \
   rpc/protocol.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -125,6 +125,7 @@ BITCOIN_CORE_H = \
   policy/policylist.h \
   policy/whitelist.h \
   policy/kycfile.h \
+  policy/requestlist.h \
   pow.h \
   protocol.h \
   random.h \
@@ -205,6 +206,7 @@ libbitcoin_server_a_SOURCES = \
   policy/policy.cpp \
   policy/policylist.cpp \
   policy/whitelist.cpp \
+  policy/requestlist.cpp \
   pow.cpp \
   rest.cpp \
   rpc/blockchain.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -121,6 +121,7 @@ BITCOIN_TESTS =\
   test/scheduler_tests.cpp \
   test/script_P2SH_tests.cpp \
   test/script_tests.cpp \
+  test/script_standard_tests.cpp \
   test/scriptnum_tests.cpp \
   test/serialize_tests.cpp \
   test/sighash_tests.cpp \
@@ -159,7 +160,7 @@ if ENABLE_WALLET
 test_test_ocean_LDADD += $(LIBBITCOIN_WALLET)
 endif
 
-test_test_ocean_LDADD += $(LIBBITCOIN_CONSENSUS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_LIBS) $(EVENT_PTHREADS_LIBS) 
+test_test_ocean_LDADD += $(LIBBITCOIN_CONSENSUS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_LIBS) $(EVENT_PTHREADS_LIBS)
 test_test_ocean_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) -static
 
 if ENABLE_ZMQ
@@ -170,8 +171,8 @@ endif
 # test_bitcoin_fuzzy binary #
 test_test_ocean_fuzzy_SOURCES = test/test_bitcoin_fuzzy.cpp
 test_test_ocean_fuzzy_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
-test_test_ocean_fuzzy_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS) 
-test_test_ocean_fuzzy_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) 
+test_test_ocean_fuzzy_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_test_ocean_fuzzy_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 
 test_test_ocean_fuzzy_LDADD = \
   $(LIBUNIVALUE) \
@@ -182,7 +183,7 @@ test_test_ocean_fuzzy_LDADD = \
   $(LIBBITCOIN_CRYPTO) \
   $(LIBSECP256K1)
 
-test_test_ocean_fuzzy_LDADD += $(BOOST_LIBS) $(CRYPTO_LIBS) 
+test_test_ocean_fuzzy_LDADD += $(BOOST_LIBS) $(CRYPTO_LIBS)
 #
 
 nodist_test_test_ocean_SOURCES = $(GENERATED_TEST_FILES)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1687,9 +1687,10 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     if(chainActive.Height() > 1) {
-        if(fRequireFreezelistCheck) LoadFreezeList(pcoinsTip);
-        if(fEnableBurnlistCheck) LoadBurnList(pcoinsTip);
-        if(fRequireWhitelistCheck || fScanWhitelist) addressWhitelist.Load(pcoinsTip);
+        if (fRequireFreezelistCheck) LoadFreezeList(pcoinsTip);
+        if (fEnableBurnlistCheck) LoadBurnList(pcoinsTip);
+        if (fRequireWhitelistCheck || fScanWhitelist) addressWhitelist.Load(pcoinsTip);
+        if (fRequestList) requestList.Load(pcoinsTip, chainActive.Height());
     }
 
     // ********************************************************* Step 11: start node

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1107,7 +1107,7 @@ bool AppInitParameterInteraction()
     fRequireFreezelistCheck = GetBoolArg("-freezelist", DEFAULT_FREEZELIST_CHECK);
     fEnableBurnlistCheck = GetBoolArg("-burnlist", DEFAULT_BURNLIST_CHECK);
     fblockissuancetx = GetBoolArg("-issuanceblock", DEFAULT_BLOCK_ISSUANCE);
-    fEnableBurnlistCheck = GetBoolArg("-burnlist", DEFAULT_BURNLIST_CHECK);
+    fRequestList = GetBoolArg("-requestlist", DEFAULT_REQUEST_LIST);
     fIsBareMultisigStd = GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
     //Acceptance of data in OP_RETURN
     fAcceptDatacarrier = GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -391,7 +391,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u)"), defaultChainParams->GetDefaultPort()));
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
     strUsage += HelpMessageOpt("-proxyrandomize", strprintf(_("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)"), DEFAULT_PROXYRANDOMIZE));
-    strUsage += HelpMessageOpt("-requestlist", strprintf(_("TODO: Add Message ..."), DEFAULT_REQUESTLIST_CHECK));
+    strUsage += HelpMessageOpt("-requestlist", strprintf(_("Store the list of service requests"), DEFAULT_REQUEST_LIST));
     strUsage += HelpMessageOpt("-rpcserialversion", strprintf(_("Sets the serialization of raw transaction or block hex returned in non-verbose mode, non-segwit(0) or segwit(1) (default: %d)"), DEFAULT_RPC_SERIALIZE_VERSION));
     strUsage += HelpMessageOpt("-seednode=<ip>", _("Connect to a node to retrieve peer addresses, and disconnect"));
     strUsage += HelpMessageOpt("-timeout=<n>", strprintf(_("Specify connection timeout in milliseconds (minimum: 1, default: %d)"), DEFAULT_CONNECT_TIMEOUT));

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -50,6 +50,14 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
             return false;
         if (m < 1 || m > n)
             return false;
+    } else if (whichType == TX_LOCKED_MULTISIG) {
+        unsigned char m = (*(vSolutions.begin() + 1))[0];
+        unsigned char n = vSolutions.back()[0];
+        // Support up to x-of-3 multisig txns as standard
+        if (n < 1 || n > 3)
+            return false;
+        if (m < 1 || m > n)
+            return false;
     } else if (whichType == TX_NULL_DATA &&
                (!fAcceptDatacarrier || scriptPubKey.size() > nMaxDatacarrierBytes))
           return false;
@@ -89,7 +97,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
             reason = "scriptpubkey";
             return false;
         }
-        if ((whichType == TX_MULTISIG) && (!fIsBareMultisigStd)) {
+        if ((whichType == TX_MULTISIG || whichType == TX_LOCKED_MULTISIG) && (!fIsBareMultisigStd)) {
             reason = "bare-multisig";
             return false;
         } else if (txout.nAsset.IsExplicit() && txout.IsDust(dustRelayFee)) {

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -381,6 +381,21 @@ bool UpdateBurnList(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     return true;
 }
 
+bool UpdateRequestList(const CTransaction& tx, const CCoinsViewCache& mapInputs)
+{
+    if (tx.IsCoinBase() || tx.vout.size() != 1)
+        return false;
+
+    txnouttype whichType;
+    vector<vector<unsigned char>> vSolutions;
+    if (Solver(tx.vout[0].scriptPubKey, whichType, vSolutions) && whichType == TX_LOCKED_MULTISIG) {
+        auto request = CRequest::FromSolutions(vSolutions);
+        requestList.add(tx.GetHash(), &request);
+        return true;
+    }
+    return false;
+}
+
 bool UpdateAssetMap(const CTransaction& tx)
 {
     if(!tx.vin[0].assetIssuance.IsNull()){

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -153,6 +153,10 @@ bool UpdateFreezeList(const CTransaction& tx, const CCoinsViewCache& mapInputs);
     */
 bool UpdateBurnList(const CTransaction& tx, const CCoinsViewCache& mapInputs);
 
+
+/** Update the request list with the input transaction */
+bool UpdateRequestList(const CTransaction& tx, const CCoinsViewCache& mapInputs);
+
     //function to scan the UTXO set for freezelist addresses
 bool LoadFreezeList(CCoinsView *view);
 

--- a/src/policy/requestlist.cpp
+++ b/src/policy/requestlist.cpp
@@ -4,6 +4,7 @@
 
 #include "requestlist.h"
 #include "policy/policy.h"
+#include "util.h"
 
 CRequestList::CRequestList(){;}
 CRequestList::~CRequestList(){;}
@@ -64,5 +65,5 @@ bool CRequestList::Load(CCoinsView *view)
         }
         pcursor->Next();
     }
-    return;
+    return true;
 }

--- a/src/policy/requestlist.cpp
+++ b/src/policy/requestlist.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2019 The CommerceBlock Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "requestlist.h"
+#include "policy/policy.h"
+
+CRequestList::CRequestList(){;}
+CRequestList::~CRequestList(){;}
+
+std::pair<bool, CRequestList::baseIter> CRequestList::find(const uint256 &txid)
+{
+  boost::recursive_mutex::scoped_lock scoped_lock(_mtx);
+  base::find(txid);
+}
+
+void CRequestList::clear()
+{
+  boost::recursive_mutex::scoped_lock scoped_lock(_mtx);
+  return base::clear();
+}
+
+void CRequestList::remove(const uint256 &txid)
+{
+  boost::recursive_mutex::scoped_lock scoped_lock(_mtx);
+  baseIter it = base::find(txid);
+  if(it != this->end())
+    base::erase(it);
+}
+
+CRequestList::base::size_type CRequestList::size()
+{
+  boost::recursive_mutex::scoped_lock scoped_lock(_mtx);
+  return base::size();
+}
+
+void CRequestList::add(const uint256 &txid, CRequest *req)
+{
+  boost::recursive_mutex::scoped_lock scoped_lock(_mtx);
+  base::insert(std::make_pair(txid, *req));
+}
+
+/** Load request list from utxo set */
+bool CRequestList::Load(CCoinsView *view)
+{
+    std::unique_ptr<CCoinsViewCursor> pcursor(view->Cursor());
+    while (pcursor->Valid()) {
+        boost::this_thread::interruption_point();
+        uint256 key;
+        CCoins coins;
+        if (pcursor->GetKey(key) && pcursor->GetValue(coins)) {
+            if (coins.vout.size() == 1 && !coins.IsCoinBase() &&
+            coins.vout[0].nAsset.IsExplicit() && coins.vout[0].nAsset.GetAsset() == permissionAsset) {
+                vector<vector<unsigned char>> vSolutions;
+                txnouttype whichType;
+                if (Solver(coins.vout[0].scriptPubKey, whichType, vSolutions)
+                && whichType == TX_LOCKED_MULTISIG) {
+                    auto request = CRequest::FromSolutions(vSolutions);
+                    add(key, &request);
+                }
+            }
+        } else {
+            return error("%s: unable to read value", __func__);
+        }
+        pcursor->Next();
+    }
+    return;
+}

--- a/src/policy/requestlist.h
+++ b/src/policy/requestlist.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 The CommerceBlock Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Class to store the list of requests
+
+#ifndef OCEAN_REQUEST_LIST_H
+#define OCEAN_REQUEST_LIST_H
+
+#include <boost/thread/recursive_mutex.hpp>
+#include <boost/thread/mutex.hpp>
+
+#include <request.h>
+#include <coins.h>
+
+class CRequestList : private std::map<uint256, CRequest>
+{
+    using base = std::map<uint256, CRequest>;
+    using baseIter = base::iterator;
+
+public:
+    CRequestList();
+    virtual ~CRequestList();
+
+    //Enable public access to base class iterator accessors
+    using base::begin;
+    using base::end;
+
+    void lock(){_mtx.lock();}
+    void unlock(){_mtx.unlock();}
+
+    std::pair<bool, baseIter> find(const uint256 &txid);
+    void clear();
+    void remove(const uint256 &txid);
+    void add(const uint256 &txid, CRequest *req);
+    base::size_type size();
+
+    // Load request list for utxo set
+    bool Load(CCoinsView *view);
+
+protected:
+    boost::recursive_mutex _mtx;
+};
+
+#endif // OCEAN_REQUEST_LIST_H

--- a/src/policy/requestlist.h
+++ b/src/policy/requestlist.h
@@ -36,7 +36,11 @@ public:
     base::size_type size();
 
     // Load request list for utxo set
-    bool Load(CCoinsView *view);
+    bool Load(CCoinsView *view, uint32_t nHeight);
+
+    // Remove any expired requests
+    void RemoveExpired(uint32_t nHeight);
+
 
 protected:
     boost::recursive_mutex _mtx;

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -38,21 +38,37 @@ typedef uint256 ChainCode;
 /** An encapsulated public key. */
 class CPubKey
 {
+public:
+    /**
+     * secp256k1:
+     */
+    static constexpr unsigned int PUBLIC_KEY_SIZE             = 65;
+    static constexpr unsigned int COMPRESSED_PUBLIC_KEY_SIZE  = 33;
+    static constexpr unsigned int SIGNATURE_SIZE              = 72;
+    static constexpr unsigned int COMPACT_SIGNATURE_SIZE      = 65;
+    /**
+     * see www.keylength.com
+     * script supports up to 75 for single byte push
+     */
+    static_assert(
+        PUBLIC_KEY_SIZE >= COMPRESSED_PUBLIC_KEY_SIZE,
+        "COMPRESSED_PUBLIC_KEY_SIZE is larger than PUBLIC_KEY_SIZE");
+
 private:
 
     /**
      * Just store the serialized data.
      * Its length can very cheaply be computed from the first byte.
      */
-    unsigned char vch[65];
+    unsigned char vch[PUBLIC_KEY_SIZE];
 
     //! Compute the length of a pubkey with a given first byte.
     unsigned int static GetLen(unsigned char chHeader)
     {
         if (chHeader == 2 || chHeader == 3)
-            return 33;
+            return COMPRESSED_PUBLIC_KEY_SIZE;
         if (chHeader == 4 || chHeader == 6 || chHeader == 7)
-            return 65;
+            return PUBLIC_KEY_SIZE;
         return 0;
     }
 
@@ -63,6 +79,11 @@ private:
     }
 
 public:
+
+    bool static ValidSize(const std::vector<unsigned char> &vch) {
+      return vch.size() > 0 && GetLen(vch[0]) == vch.size();
+    }
+
     //! Construct an invalid public key.
     CPubKey()
     {
@@ -127,7 +148,7 @@ public:
     void Unserialize(Stream& s)
     {
         unsigned int len = ::ReadCompactSize(s);
-        if (len <= 65) {
+        if (len <= PUBLIC_KEY_SIZE) {
             s.read((char*)vch, len);
         } else {
             // invalid pubkey, skip available data
@@ -166,7 +187,7 @@ public:
     //! Check whether this is a compressed public key.
     bool IsCompressed() const
     {
-        return size() == 33;
+        return size() == COMPRESSED_PUBLIC_KEY_SIZE;
     }
 
     /**

--- a/src/request.h
+++ b/src/request.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 The CommerceBlock Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef OCEAN_REQUEST_H
+#define OCEAN_REQUEST_H
+
+using namespace std;
+
+/** Class for service request winning bids */
+class CBid {};
+
+/** Class for service requests */
+class CRequest {
+public:
+    int32_t nNumTickets;
+    int32_t nDecayConst;
+    int32_t nFeePercentage;
+    int32_t nStartBlockHeight;
+    int32_t nEndBlockHeight;
+    uint256 hashGenesis;
+    set<CBid> vBids;
+
+    static CRequest FromSolutions(const vector<vector<unsigned char>> &vSolutions) {
+        CRequest request;
+        request.nEndBlockHeight = CScriptNum(vSolutions[0], true).getint();
+        char pubInt;
+        CDataStream output3(vSolutions[3], SER_NETWORK, PROTOCOL_VERSION);
+        output3 >> pubInt;
+        output3 >> request.hashGenesis;
+        CDataStream output4(vSolutions[4], SER_NETWORK, PROTOCOL_VERSION);
+        output4 >> pubInt;
+        output4 >> request.nStartBlockHeight;
+        output4 >> request.nNumTickets;
+        output4 >> request.nDecayConst;
+        output4 >> request.nFeePercentage;
+        return request;
+    }
+};
+
+#endif // OCEAN_REQUEST_H

--- a/src/request.h
+++ b/src/request.h
@@ -5,6 +5,11 @@
 #ifndef OCEAN_REQUEST_H
 #define OCEAN_REQUEST_H
 
+#include "version.h"
+#include "streams.h"
+#include "uint256.h"
+#include "script/script.h"
+
 using namespace std;
 
 /** Class for service request winning bids */
@@ -19,9 +24,12 @@ public:
     int32_t nStartBlockHeight;
     int32_t nEndBlockHeight;
     uint256 hashGenesis;
-    set<CBid> vBids;
 
-    static CRequest FromSolutions(const vector<vector<unsigned char>> &vSolutions) {
+    // removed until CBid class is finalized
+    //set<CBid> vBids;
+
+    static CRequest FromSolutions(const vector<vector<unsigned char>> &vSolutions)
+    {
         CRequest request;
         request.nEndBlockHeight = CScriptNum(vSolutions[0], true).getint();
         char pubInt;

--- a/src/request.h
+++ b/src/request.h
@@ -18,11 +18,11 @@ class CBid {};
 /** Class for service requests */
 class CRequest {
 public:
-    int32_t nNumTickets;
-    int32_t nDecayConst;
-    int32_t nFeePercentage;
-    int32_t nStartBlockHeight;
-    int32_t nEndBlockHeight;
+    uint32_t nNumTickets;
+    uint32_t nDecayConst;
+    uint32_t nFeePercentage;
+    uint32_t nStartBlockHeight;
+    uint32_t nEndBlockHeight;
     uint256 hashGenesis;
 
     // removed until CBid class is finalized

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1048,7 +1048,8 @@ UniValue getrequests(const JSONRPCRequest& request)
             if (coins.vout.size() == 1 && !coins.IsCoinBase() &&
             coins.vout[0].nAsset.IsExplicit() && coins.vout[0].nAsset.GetAsset() == permissionAsset) {
                 vector<vector<unsigned char>> vSolutions;
-                if (SolverRequests(coins.vout[0].scriptPubKey, vSolutions)) {
+                txnouttype whichType;
+                if (Solver(coins.vout[0].scriptPubKey, whichType, vSolutions) && whichType == TX_LOCKED_MULTISIG) {
                     int endBlockHeight = CScriptNum(vSolutions[0], true).getint();
                     if (endBlockHeight >= chainActive.Height()) { // check request active
                         UniValue item(UniValue::VOBJ);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1007,11 +1007,11 @@ UniValue requestToJSON(const CRequest &request)
 {
     UniValue item(UniValue::VOBJ);
     item.push_back(Pair("genesisBlock", request.hashGenesis.GetHex()));
-    item.push_back(Pair("startBlockHeight", request.nStartBlockHeight));
-    item.push_back(Pair("numTickets", request.nNumTickets));
-    item.push_back(Pair("decayConst", request.nDecayConst));
-    item.push_back(Pair("feePercentage", request.nFeePercentage));
-    item.push_back(Pair("endBlockHeight", request.nEndBlockHeight));
+    item.push_back(Pair("startBlockHeight", (int32_t)request.nStartBlockHeight));
+    item.push_back(Pair("numTickets", (int32_t)request.nNumTickets));
+    item.push_back(Pair("decayConst", (int32_t)request.nDecayConst));
+    item.push_back(Pair("feePercentage", (int32_t)request.nFeePercentage));
+    item.push_back(Pair("endBlockHeight", (int32_t)request.nEndBlockHeight));
     return item;
 }
 
@@ -1075,7 +1075,7 @@ UniValue getrequests(const JSONRPCRequest& request)
                 txnouttype whichType;
                 if (Solver(coins.vout[0].scriptPubKey, whichType, vSolutions) && whichType == TX_LOCKED_MULTISIG) {
                     auto request = CRequest::FromSolutions(vSolutions);
-                    if (request.nEndBlockHeight >= chainActive.Height()) { // check request active
+                    if ((int32_t)request.nEndBlockHeight >= chainActive.Height()) { // check request active
                         if (!fGenesisCheck || (request.hashGenesis == hash)) {
                             auto item = requestToJSON(request);
                             item.push_back(Pair("txid", key.ToString()));

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -155,7 +155,7 @@ public:
             BOOST_FOREACH(const CTxDestination& addr, addresses)
                 a.push_back(CBitcoinAddress(addr).ToString());
             obj.push_back(Pair("addresses", a));
-            if (whichType == TX_MULTISIG)
+            if (whichType == TX_MULTISIG || whichType == TX_LOCKED_MULTISIG)
                 obj.push_back(Pair("sigsrequired", nRequired));
         }
         return obj;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -572,7 +572,7 @@ static inline void createrawrequesttx_output(CMutableTransaction& rawTx,
 
     rawTx.vout.push_back(
         CTxOut(asset, amount,
-            CScript() << endBlockHeight.get_int() << OP_CHECKLOCKTIMEVERIFY << OP_DROP
+            CScript() << CScriptNum(endBlockHeight.get_int()) << OP_CHECKLOCKTIMEVERIFY << OP_DROP
                       << CScript::EncodeOP_N(1)
                       << ToByteVector(targetPubKey)
                       << ToByteVector(datapubkey2)

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -156,11 +156,6 @@ const char* GetOpName(opcodetype opcode)
 
     case OP_INVALIDOPCODE          : return "OP_INVALIDOPCODE";
 
-    // Note:
-    //  The template matching params OP_SMALLINTEGER/etc are defined in opcodetype enum
-    //  as kind of implementation hack, they are *NOT* real opcodes.  If found in real
-    //  Script, just let the default: case deal with them.
-
     default:
         return "OP_UNKNOWN";
     }
@@ -230,7 +225,7 @@ bool CScript::IsPegoutScript(uint256& genesis_hash, CScript& pegout_scriptpubkey
         return false;
     }
     genesis_hash = uint256(data);
-  
+
     // Read in parent chain destination scriptpubkey
     if (!GetOp(pc, opcode, data) || data.size() == 0 ) {
         return false;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -42,79 +42,33 @@ const char* GetTxnOutputType(txnouttype t)
     case TX_WITNESS_V0_SCRIPTHASH: return "witness_v0_scripthash";
     case TX_TRUE: return "true";
     case TX_FEE: return "fee";
+    case TX_LOCKED_MULTISIG: return "lockedmultisig";
     }
     return NULL;
 }
 
-/*
- * Solver for request transactions only
- */
-bool SolverRequests(const CScript& scriptPubKey, vector<vector<unsigned char> >& vSolutionsRet)
+/** Check push data opcode is between 1 and 5 bytes for OP_CHECKLOCKTIMEVERIFY argument */
+static constexpr bool IsCheckLockTimeSize(opcodetype opcode)
 {
-    opcodetype opcode1, opcode2;
-    vector<unsigned char> vch1, vch2;
-    CScript::const_iterator pc1 = scriptPubKey.begin();
+    return opcode >=1 && opcode <= 5;
+}
 
-    vSolutionsRet.clear();
+static bool MatchLocked(const CScript& script, valtype& locktime)
+{
+    opcodetype opcode1;
+    vector<unsigned char> vch1;
+    CScript::const_iterator pc1 = script.begin();
 
-    // first attempt to parse a number that comes before OP_CHECKLOCKTIMEVERIFY
-    // TODO: maybe implement a new template for 5 bytes data
-    if (!scriptPubKey.GetOp(pc1, opcode1, vch1))
+    // Attempt to parse locktime parameter of OP_CHECKLOCKTIMEVERIFY
+    if (!script.GetOp(pc1, opcode1, vch1))
         return false;
-    if (opcode1 >=1 && opcode1 <= 5) { // check data allow max 5 bytes length
+    if (IsCheckLockTimeSize(opcode1)
+            && script.size() >= 3 + opcode1
+            && script[1 + opcode1] == OP_CHECKLOCKTIMEVERIFY
+            && script[2 + opcode1] == OP_DROP) {
         const CScriptNum nLockTime(vch1, true, 5);
-        vSolutionsRet.push_back(nLockTime.getvch());
-    } else {
-        return false;
-    }
-
-    // add template for the remaining part of the script
-    const CScript script2 = CScript() << OP_CHECKLOCKTIMEVERIFY << OP_DROP
-        << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG;
-    CScript::const_iterator pc2 = script2.begin();
-    while (true)
-    {
-        if (pc1 == scriptPubKey.end() && pc2 == script2.end())
-        {
-            unsigned char m = vSolutionsRet[1][0];
-            unsigned char n = vSolutionsRet.back()[0];
-            if (m < 1 || n < 1 || m > n || vSolutionsRet.size()-2-1 != n)
-                return false;
-            return true;
-        }
-        if (!scriptPubKey.GetOp(pc1, opcode1, vch1)) {
-            break;
-        }
-        if (!script2.GetOp(pc2, opcode2, vch2)) {
-            break;
-        }
-
-        if (opcode2 == OP_PUBKEYS)
-        {
-            while (vch1.size() >= 33 && vch1.size() <= 65)
-            {
-                vSolutionsRet.push_back(vch1);
-                if (!scriptPubKey.GetOp(pc1, opcode1, vch1))
-                    break;
-            }
-            if (!script2.GetOp(pc2, opcode2, vch2))
-                break;
-        }
-        if (opcode2 == OP_SMALLINTEGER)
-        {
-            if (opcode1 == OP_0 ||
-                (opcode1 >= OP_1 && opcode1 <= OP_16))
-            {
-                char n = (char)CScript::DecodeOP_N(opcode1);
-                vSolutionsRet.push_back(valtype(1, n));
-            }
-            else
-                break;
-        }
-        else if (opcode1 != opcode2 || vch1 != vch2)
-        {
-            break;
-        }
+        locktime = nLockTime.getvch();
+        return true;
     }
     return false;
 }
@@ -241,10 +195,20 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
         return true;
     }
 
+    // Before checking for multisig, check if script is locked and if that is
+    // the case skip the LOCKTIME OP_CHECKLOCKTIMEVERIFY OP_DROP of the script
+    bool fIsLocked = false;
+    CScript scriptPubKeyLocked;
+    if (MatchLocked(scriptPubKey, data)) {
+        fIsLocked = true;
+        scriptPubKeyLocked = CScript(scriptPubKey.begin() + 3 + data.size(), scriptPubKey.end());
+        vSolutionsRet.push_back(std::move(data)); // push lock time data
+    }
+
     unsigned int required;
     std::vector<std::vector<unsigned char>> keys;
-    if (MatchMultisig(scriptPubKey, required, keys)) {
-        typeRet = TX_MULTISIG;
+    if (MatchMultisig(fIsLocked ? scriptPubKeyLocked : scriptPubKey, required, keys)) {
+        typeRet = fIsLocked ? TX_LOCKED_MULTISIG : TX_MULTISIG;
         vSolutionsRet.push_back({static_cast<unsigned char>(required)}); // safe as required is in range 1..16
         vSolutionsRet.insert(vSolutionsRet.end(), keys.begin(), keys.end());
         vSolutionsRet.push_back({static_cast<unsigned char>(keys.size())}); // safe as size is in range 1..16

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -58,12 +58,10 @@ bool SolverRequests(const CScript& scriptPubKey, vector<vector<unsigned char> >&
     vSolutionsRet.clear();
 
     // first attempt to parse a number that comes before OP_CHECKLOCKTIMEVERIFY
+    // TODO: maybe implement a new template for 5 bytes data
     if (!scriptPubKey.GetOp(pc1, opcode1, vch1))
         return false;
-    if (opcode1 >= OP_1 && opcode1 <= OP_16) { // edge case num is between 1 - 16
-        CScriptNum bn((int)opcode1 - (int)(OP_1 - 1));
-        vSolutionsRet.push_back(bn.getvch());
-    } else if (opcode1 >=1 && opcode1 <= 5) { // check data allow max 5 bytes length
+    if (opcode1 >=1 && opcode1 <= 5) { // check data allow max 5 bytes length
         const CScriptNum nLockTime(vch1, true, 5);
         vSolutionsRet.push_back(nLockTime.getvch());
     } else {

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -119,25 +119,57 @@ bool SolverRequests(const CScript& scriptPubKey, vector<vector<unsigned char> >&
     return false;
 }
 
+static bool MatchPayToPubkey(const CScript& script, valtype& pubkey)
+{
+    if (script.size() == CPubKey::PUBLIC_KEY_SIZE + 2 && script[0] == CPubKey::PUBLIC_KEY_SIZE && script.back() == OP_CHECKSIG) {
+        pubkey = valtype(script.begin() + 1, script.begin() + CPubKey::PUBLIC_KEY_SIZE + 1);
+        return CPubKey::ValidSize(pubkey);
+    }
+    if (script.size() == CPubKey::COMPRESSED_PUBLIC_KEY_SIZE + 2 && script[0] == CPubKey::COMPRESSED_PUBLIC_KEY_SIZE && script.back() == OP_CHECKSIG) {
+        pubkey = valtype(script.begin() + 1, script.begin() + CPubKey::COMPRESSED_PUBLIC_KEY_SIZE + 1);
+        return CPubKey::ValidSize(pubkey);
+    }
+    return false;
+}
+
+static bool MatchPayToPubkeyHash(const CScript& script, valtype& pubkeyhash)
+{
+    if (script.size() == 25 && script[0] == OP_DUP && script[1] == OP_HASH160 && script[2] == 20 && script[23] == OP_EQUALVERIFY && script[24] == OP_CHECKSIG) {
+        pubkeyhash = valtype(script.begin () + 3, script.begin() + 23);
+        return true;
+    }
+    return false;
+}
+
+/** Test for "small positive integer" script opcodes - OP_1 through OP_16. */
+static constexpr bool IsSmallInteger(opcodetype opcode)
+{
+    return opcode >= OP_1 && opcode <= OP_16;
+}
+
+static bool MatchMultisig(const CScript& script, unsigned int& required, std::vector<valtype>& pubkeys)
+{
+    opcodetype opcode;
+    valtype data;
+    CScript::const_iterator it = script.begin();
+    if (script.size() < 1 || script.back() != OP_CHECKMULTISIG) return false;
+
+    if (!script.GetOp(it, opcode, data) || !IsSmallInteger(opcode)) return false;
+    required = CScript::DecodeOP_N(opcode);
+    while (script.GetOp(it, opcode, data) && CPubKey::ValidSize(data)) {
+        pubkeys.emplace_back(std::move(data));
+    }
+    if (!IsSmallInteger(opcode)) return false;
+    unsigned int keys = CScript::DecodeOP_N(opcode);
+    if (pubkeys.size() != keys || keys < required) return false;
+    return (it + 1 == script.end());
+}
+
 /**
  * Return public keys or hashes from scriptPubKey, for 'standard' transaction types.
  */
 bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsigned char> >& vSolutionsRet)
 {
-    // Templates
-    static multimap<txnouttype, CScript> mTemplates;
-    if (mTemplates.empty())
-    {
-        // Standard tx, sender provides pubkey, receiver adds signature
-        mTemplates.insert(make_pair(TX_PUBKEY, CScript() << OP_PUBKEY << OP_CHECKSIG));
-
-        // Bitcoin address tx, sender provides hash of pubkey, receiver provides signature and pubkey
-        mTemplates.insert(make_pair(TX_PUBKEYHASH, CScript() << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG));
-
-        // Sender provides N pubkeys, receivers provides M signatures
-        mTemplates.insert(make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
-    }
-
     vSolutionsRet.clear();
 
     // Shortcut for pay-to-script-hash, which are more constrained than the other types:
@@ -196,84 +228,27 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
         return true;
     }
 
-    // Scan templates
-    const CScript& script1 = scriptPubKey;
-    BOOST_FOREACH(const PAIRTYPE(txnouttype, CScript)& tplate, mTemplates)
-    {
-        const CScript& script2 = tplate.second;
-        vSolutionsRet.clear();
+    std::vector<unsigned char> data;
+    if (MatchPayToPubkey(scriptPubKey, data)) {
+        typeRet = TX_PUBKEY;
+        vSolutionsRet.push_back(std::move(data));
+        return true;
+    }
 
-        opcodetype opcode1, opcode2;
-        vector<unsigned char> vch1, vch2;
+    if (MatchPayToPubkeyHash(scriptPubKey, data)) {
+        typeRet = TX_PUBKEYHASH;
+        vSolutionsRet.push_back(std::move(data));
+        return true;
+    }
 
-        // Compare
-        CScript::const_iterator pc1 = script1.begin();
-        CScript::const_iterator pc2 = script2.begin();
-        while (true)
-        {
-            if (pc1 == script1.end() && pc2 == script2.end())
-            {
-                // Found a match
-                typeRet = tplate.first;
-                if (typeRet == TX_MULTISIG)
-                {
-                    // Additional checks for TX_MULTISIG:
-                    unsigned char m = vSolutionsRet.front()[0];
-                    unsigned char n = vSolutionsRet.back()[0];
-                    if (m < 1 || n < 1 || m > n || vSolutionsRet.size()-2 != n)
-                        return false;
-                }
-                return true;
-            }
-            if (!script1.GetOp(pc1, opcode1, vch1))
-                break;
-            if (!script2.GetOp(pc2, opcode2, vch2))
-                break;
-
-            // Template matching opcodes:
-            if (opcode2 == OP_PUBKEYS)
-            {
-                while (vch1.size() >= 33 && vch1.size() <= 65)
-                {
-                    vSolutionsRet.push_back(vch1);
-                    if (!script1.GetOp(pc1, opcode1, vch1))
-                        break;
-                }
-                if (!script2.GetOp(pc2, opcode2, vch2))
-                    break;
-                // Normal situation is to fall through
-                // to other if/else statements
-            }
-
-            if (opcode2 == OP_PUBKEY)
-            {
-                if (vch1.size() < 33 || vch1.size() > 65)
-                    break;
-                vSolutionsRet.push_back(vch1);
-            }
-            else if (opcode2 == OP_PUBKEYHASH)
-            {
-                if (vch1.size() != sizeof(uint160))
-                    break;
-                vSolutionsRet.push_back(vch1);
-            }
-            else if (opcode2 == OP_SMALLINTEGER)
-            {   // Single-byte small integer pushed onto vSolutions
-                if (opcode1 == OP_0 ||
-                    (opcode1 >= OP_1 && opcode1 <= OP_16))
-                {
-                    char n = (char)CScript::DecodeOP_N(opcode1);
-                    vSolutionsRet.push_back(valtype(1, n));
-                }
-                else
-                    break;
-            }
-            else if (opcode1 != opcode2 || vch1 != vch2)
-            {
-                // Others must match exactly
-                break;
-            }
-        }
+    unsigned int required;
+    std::vector<std::vector<unsigned char>> keys;
+    if (MatchMultisig(scriptPubKey, required, keys)) {
+        typeRet = TX_MULTISIG;
+        vSolutionsRet.push_back({static_cast<unsigned char>(required)}); // safe as required is in range 1..16
+        vSolutionsRet.insert(vSolutionsRet.end(), keys.begin(), keys.end());
+        vSolutionsRet.push_back({static_cast<unsigned char>(keys.size())}); // safe as size is in range 1..16
+        return true;
     }
 
     vSolutionsRet.clear();

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -61,6 +61,7 @@ enum txnouttype
     TX_WITNESS_V0_KEYHASH,
     TX_TRUE,
     TX_FEE,
+    TX_LOCKED_MULTISIG,
 };
 
 class CNoDestination {

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -1,0 +1,746 @@
+// Copyright (c) 2017-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <key.h>
+#include <keystore.h>
+#include <script/ismine.h>
+#include <script/script.h>
+#include <script/script_error.h>
+#include <script/standard.h>
+#include <test/test_bitcoin.h>
+
+#include <boost/test/unit_test.hpp>
+
+
+BOOST_FIXTURE_TEST_SUITE(script_standard_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
+{
+    CKey keys[3];
+    CPubKey pubkeys[3];
+    for (int i = 0; i < 3; i++) {
+        keys[i].MakeNewKey(true);
+        pubkeys[i] = keys[i].GetPubKey();
+    }
+
+    CScript s;
+    txnouttype whichType;
+    std::vector<std::vector<unsigned char> > solutions;
+
+    // TX_PUBKEY
+    s.clear();
+    s << ToByteVector(pubkeys[0]) << OP_CHECKSIG;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_PUBKEY);
+    BOOST_CHECK_EQUAL(solutions.size(), 1U);
+    BOOST_CHECK(solutions[0] == ToByteVector(pubkeys[0]));
+
+    // TX_PUBKEYHASH
+    s.clear();
+    s << OP_DUP << OP_HASH160 << ToByteVector(pubkeys[0].GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_PUBKEYHASH);
+    BOOST_CHECK_EQUAL(solutions.size(), 1U);
+    BOOST_CHECK(solutions[0] == ToByteVector(pubkeys[0].GetID()));
+
+    // TX_SCRIPTHASH
+    CScript redeemScript(s); // initialize with leftover P2PKH script
+    s.clear();
+    s << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_SCRIPTHASH);
+    BOOST_CHECK_EQUAL(solutions.size(), 1U);
+    BOOST_CHECK(solutions[0] == ToByteVector(CScriptID(redeemScript)));
+
+    // TX_MULTISIG
+    s.clear();
+    s << OP_1 <<
+        ToByteVector(pubkeys[0]) <<
+        ToByteVector(pubkeys[1]) <<
+        OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_MULTISIG);
+    BOOST_CHECK_EQUAL(solutions.size(), 4U);
+    BOOST_CHECK(solutions[0] == std::vector<unsigned char>({1}));
+    BOOST_CHECK(solutions[1] == ToByteVector(pubkeys[0]));
+    BOOST_CHECK(solutions[2] == ToByteVector(pubkeys[1]));
+    BOOST_CHECK(solutions[3] == std::vector<unsigned char>({2}));
+
+    s.clear();
+    s << OP_2 <<
+        ToByteVector(pubkeys[0]) <<
+        ToByteVector(pubkeys[1]) <<
+        ToByteVector(pubkeys[2]) <<
+        OP_3 << OP_CHECKMULTISIG;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_MULTISIG);
+    BOOST_CHECK_EQUAL(solutions.size(), 5U);
+    BOOST_CHECK(solutions[0] == std::vector<unsigned char>({2}));
+    BOOST_CHECK(solutions[1] == ToByteVector(pubkeys[0]));
+    BOOST_CHECK(solutions[2] == ToByteVector(pubkeys[1]));
+    BOOST_CHECK(solutions[3] == ToByteVector(pubkeys[2]));
+    BOOST_CHECK(solutions[4] == std::vector<unsigned char>({3}));
+
+    // TX_NULL_DATA
+    s.clear();
+    s << OP_RETURN <<
+        std::vector<unsigned char>({0}) <<
+        std::vector<unsigned char>({75}) <<
+        std::vector<unsigned char>({255});
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_NULL_DATA);
+    BOOST_CHECK_EQUAL(solutions.size(), 0U);
+
+    // TX_WITNESS_V0_KEYHASH
+    s.clear();
+    s << OP_0 << ToByteVector(pubkeys[0].GetID());
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_WITNESS_V0_KEYHASH);
+    BOOST_CHECK_EQUAL(solutions.size(), 1U);
+    BOOST_CHECK(solutions[0] == ToByteVector(pubkeys[0].GetID()));
+
+    // TX_WITNESS_V0_SCRIPTHASH
+    uint256 scriptHash;
+    CSHA256().Write(&redeemScript[0], redeemScript.size())
+        .Finalize(scriptHash.begin());
+
+    s.clear();
+    s << OP_0 << ToByteVector(scriptHash);
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_WITNESS_V0_SCRIPTHASH);
+    BOOST_CHECK_EQUAL(solutions.size(), 1U);
+    BOOST_CHECK(solutions[0] == ToByteVector(scriptHash));
+
+    // TX_NONSTANDARD
+    s.clear();
+    s << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_NONSTANDARD);
+}
+
+BOOST_AUTO_TEST_CASE(script_standard_Solver_failure)
+{
+    CKey key;
+    CPubKey pubkey;
+    key.MakeNewKey(true);
+    pubkey = key.GetPubKey();
+
+    CScript s;
+    txnouttype whichType;
+    std::vector<std::vector<unsigned char> > solutions;
+
+    // TX_PUBKEY with incorrectly sized pubkey
+    s.clear();
+    s << std::vector<unsigned char>(30, 0x01) << OP_CHECKSIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_PUBKEYHASH with incorrectly sized key hash
+    s.clear();
+    s << OP_DUP << OP_HASH160 << ToByteVector(pubkey) << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_SCRIPTHASH with incorrectly sized script hash
+    s.clear();
+    s << OP_HASH160 << std::vector<unsigned char>(21, 0x01) << OP_EQUAL;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_MULTISIG 0/2
+    s.clear();
+    s << OP_0 << ToByteVector(pubkey) << OP_1 << OP_CHECKMULTISIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_MULTISIG 2/1
+    s.clear();
+    s << OP_2 << ToByteVector(pubkey) << OP_1 << OP_CHECKMULTISIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_MULTISIG n = 2 with 1 pubkey
+    s.clear();
+    s << OP_1 << ToByteVector(pubkey) << OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_MULTISIG n = 1 with 0 pubkeys
+    s.clear();
+    s << OP_1 << OP_1 << OP_CHECKMULTISIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_NULL_DATA with other opcodes
+    s.clear();
+    s << OP_RETURN << std::vector<unsigned char>({75}) << OP_ADD;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+
+    // TX_WITNESS with incorrect program size
+    s.clear();
+    s << OP_0 << std::vector<unsigned char>(19, 0x01);
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+}
+
+BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)
+{
+    CKey key;
+    CPubKey pubkey;
+    key.MakeNewKey(true);
+    pubkey = key.GetPubKey();
+
+    CScript s;
+    CTxDestination address;
+
+    // TX_PUBKEY
+    s.clear();
+    s << ToByteVector(pubkey) << OP_CHECKSIG;
+    BOOST_CHECK(ExtractDestination(s, address));
+    BOOST_CHECK(boost::get<CKeyID>(&address) &&
+                *boost::get<CKeyID>(&address) == pubkey.GetID());
+
+    // TX_PUBKEYHASH
+    s.clear();
+    s << OP_DUP << OP_HASH160 << ToByteVector(pubkey.GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK(ExtractDestination(s, address));
+    BOOST_CHECK(boost::get<CKeyID>(&address) &&
+                *boost::get<CKeyID>(&address) == pubkey.GetID());
+
+    // TX_SCRIPTHASH
+    CScript redeemScript(s); // initialize with leftover P2PKH script
+    s.clear();
+    s << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
+    BOOST_CHECK(ExtractDestination(s, address));
+    BOOST_CHECK(boost::get<CScriptID>(&address) &&
+                *boost::get<CScriptID>(&address) == CScriptID(redeemScript));
+
+    // TX_MULTISIG
+    s.clear();
+    s << OP_1 << ToByteVector(pubkey) << OP_1 << OP_CHECKMULTISIG;
+    BOOST_CHECK(!ExtractDestination(s, address));
+
+    // TX_NULL_DATA
+    s.clear();
+    s << OP_RETURN << std::vector<unsigned char>({75});
+    BOOST_CHECK(!ExtractDestination(s, address));
+
+    // // TX_WITNESS_V0_KEYHASH
+    // s.clear();
+    // s << OP_0 << ToByteVector(pubkey.GetID());
+    // BOOST_CHECK(ExtractDestination(s, address));
+    // WitnessV0KeyHash keyhash;
+    // CHash160().Write(pubkey.begin(), pubkey.size()).Finalize(keyhash.begin());
+    // BOOST_CHECK(boost::get<WitnessV0KeyHash>(&address) && *boost::get<WitnessV0KeyHash>(&address) == keyhash);
+
+    // // TX_WITNESS_V0_SCRIPTHASH
+    // s.clear();
+    // WitnessV0ScriptHash scripthash;
+    // CSHA256().Write(redeemScript.data(), redeemScript.size()).Finalize(scripthash.begin());
+    // s << OP_0 << ToByteVector(scripthash);
+    // BOOST_CHECK(ExtractDestination(s, address));
+    // BOOST_CHECK(boost::get<WitnessV0ScriptHash>(&address) && *boost::get<WitnessV0ScriptHash>(&address) == scripthash);
+
+    // // TX_WITNESS with unknown version
+    // s.clear();
+    // s << OP_1 << ToByteVector(pubkey);
+    // BOOST_CHECK(ExtractDestination(s, address));
+    // WitnessUnknown unk;
+    // unk.length = 33;
+    // unk.version = 1;
+    // std::copy(pubkey.begin(), pubkey.end(), unk.program);
+    // BOOST_CHECK(boost::get<WitnessUnknown>(&address) && *boost::get<WitnessUnknown>(&address) == unk);
+}
+
+BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
+{
+    CKey keys[3];
+    CPubKey pubkeys[3];
+    for (int i = 0; i < 3; i++) {
+        keys[i].MakeNewKey(true);
+        pubkeys[i] = keys[i].GetPubKey();
+    }
+
+    CScript s;
+    txnouttype whichType;
+    std::vector<CTxDestination> addresses;
+    int nRequired;
+
+    // TX_PUBKEY
+    s.clear();
+    s << ToByteVector(pubkeys[0]) << OP_CHECKSIG;
+    BOOST_CHECK(ExtractDestinations(s, whichType, addresses, nRequired));
+    BOOST_CHECK_EQUAL(whichType, TX_PUBKEY);
+    BOOST_CHECK_EQUAL(addresses.size(), 1U);
+    BOOST_CHECK_EQUAL(nRequired, 1);
+    BOOST_CHECK(boost::get<CKeyID>(&addresses[0]) &&
+                *boost::get<CKeyID>(&addresses[0]) == pubkeys[0].GetID());
+
+    // TX_PUBKEYHASH
+    s.clear();
+    s << OP_DUP << OP_HASH160 << ToByteVector(pubkeys[0].GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK(ExtractDestinations(s, whichType, addresses, nRequired));
+    BOOST_CHECK_EQUAL(whichType, TX_PUBKEYHASH);
+    BOOST_CHECK_EQUAL(addresses.size(), 1U);
+    BOOST_CHECK_EQUAL(nRequired, 1);
+    BOOST_CHECK(boost::get<CKeyID>(&addresses[0]) &&
+                *boost::get<CKeyID>(&addresses[0]) == pubkeys[0].GetID());
+
+    // TX_SCRIPTHASH
+    CScript redeemScript(s); // initialize with leftover P2PKH script
+    s.clear();
+    s << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
+    BOOST_CHECK(ExtractDestinations(s, whichType, addresses, nRequired));
+    BOOST_CHECK_EQUAL(whichType, TX_SCRIPTHASH);
+    BOOST_CHECK_EQUAL(addresses.size(), 1U);
+    BOOST_CHECK_EQUAL(nRequired, 1);
+    BOOST_CHECK(boost::get<CScriptID>(&addresses[0]) &&
+                *boost::get<CScriptID>(&addresses[0]) == CScriptID(redeemScript));
+
+    // TX_MULTISIG
+    s.clear();
+    s << OP_2 <<
+        ToByteVector(pubkeys[0]) <<
+        ToByteVector(pubkeys[1]) <<
+        OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK(ExtractDestinations(s, whichType, addresses, nRequired));
+    BOOST_CHECK_EQUAL(whichType, TX_MULTISIG);
+    BOOST_CHECK_EQUAL(addresses.size(), 2U);
+    BOOST_CHECK_EQUAL(nRequired, 2);
+    BOOST_CHECK(boost::get<CKeyID>(&addresses[0]) &&
+                *boost::get<CKeyID>(&addresses[0]) == pubkeys[0].GetID());
+    BOOST_CHECK(boost::get<CKeyID>(&addresses[1]) &&
+                *boost::get<CKeyID>(&addresses[1]) == pubkeys[1].GetID());
+
+    // TX_NULL_DATA
+    s.clear();
+    s << OP_RETURN << std::vector<unsigned char>({75});
+    BOOST_CHECK(!ExtractDestinations(s, whichType, addresses, nRequired));
+}
+
+BOOST_AUTO_TEST_CASE(script_standard_GetScriptFor_)
+{
+    CKey keys[3];
+    CPubKey pubkeys[3];
+    for (int i = 0; i < 3; i++) {
+        keys[i].MakeNewKey(true);
+        pubkeys[i] = keys[i].GetPubKey();
+    }
+
+    CScript expected, result;
+
+    // CKeyID
+    expected.clear();
+    expected << OP_DUP << OP_HASH160 << ToByteVector(pubkeys[0].GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    result = GetScriptForDestination(pubkeys[0].GetID());
+    BOOST_CHECK(result == expected);
+
+    // CScriptID
+    CScript redeemScript(result);
+    expected.clear();
+    expected << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
+    result = GetScriptForDestination(CScriptID(redeemScript));
+    BOOST_CHECK(result == expected);
+
+    // CNoDestination
+    expected.clear();
+    result = GetScriptForDestination(CNoDestination());
+    BOOST_CHECK(result == expected);
+
+    // GetScriptForRawPubKey
+    expected.clear();
+    expected << ToByteVector(pubkeys[0]) << OP_CHECKSIG;
+    result = GetScriptForRawPubKey(pubkeys[0]);
+    BOOST_CHECK(result == expected);
+
+    // GetScriptForMultisig
+    expected.clear();
+    expected << OP_2 <<
+        ToByteVector(pubkeys[0]) <<
+        ToByteVector(pubkeys[1]) <<
+        ToByteVector(pubkeys[2]) <<
+        OP_3 << OP_CHECKMULTISIG;
+    result = GetScriptForMultisig(2, std::vector<CPubKey>(pubkeys, pubkeys + 3));
+    BOOST_CHECK(result == expected);
+
+    // GetScriptForWitness
+    CScript witnessScript;
+
+    witnessScript << ToByteVector(pubkeys[0]) << OP_CHECKSIG;
+    expected.clear();
+    expected << OP_0 << ToByteVector(pubkeys[0].GetID());
+    result = GetScriptForWitness(witnessScript);
+    BOOST_CHECK(result == expected);
+
+    witnessScript.clear();
+    witnessScript << OP_DUP << OP_HASH160 << ToByteVector(pubkeys[0].GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    result = GetScriptForWitness(witnessScript);
+    BOOST_CHECK(result == expected);
+
+    witnessScript.clear();
+    witnessScript << OP_1 << ToByteVector(pubkeys[0]) << OP_1 << OP_CHECKMULTISIG;
+
+    uint256 scriptHash;
+    CSHA256().Write(&witnessScript[0], witnessScript.size())
+        .Finalize(scriptHash.begin());
+
+    expected.clear();
+    expected << OP_0 << ToByteVector(scriptHash);
+    result = GetScriptForWitness(witnessScript);
+    BOOST_CHECK(result == expected);
+}
+
+BOOST_AUTO_TEST_CASE(script_standard_IsMine)
+{
+    CKey keys[2];
+    CPubKey pubkeys[2];
+    for (int i = 0; i < 2; i++) {
+        keys[i].MakeNewKey(true);
+        pubkeys[i] = keys[i].GetPubKey();
+    }
+
+    CKey uncompressedKey;
+    uncompressedKey.MakeNewKey(false);
+    CPubKey uncompressedPubkey = uncompressedKey.GetPubKey();
+
+    CScript scriptPubKey;
+    isminetype result;
+
+    // P2PK compressed
+    {
+        CBasicKeyStore keystore;
+        scriptPubKey = GetScriptForRawPubKey(pubkeys[0]);
+
+        // Keystore does not have key
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+        // Keystore has key
+        keystore.AddKey(keys[0]);
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+    }
+
+    // P2PK uncompressed
+    {
+        CBasicKeyStore keystore;
+        scriptPubKey = GetScriptForRawPubKey(uncompressedPubkey);
+
+        // Keystore does not have key
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+        // Keystore has key
+        keystore.AddKey(uncompressedKey);
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+    }
+
+    // P2PKH compressed
+    {
+        CBasicKeyStore keystore;
+        scriptPubKey = GetScriptForDestination(pubkeys[0].GetID());
+
+        // Keystore does not have key
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+        // Keystore has key
+        keystore.AddKey(keys[0]);
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+    }
+
+    // P2PKH uncompressed
+    {
+        CBasicKeyStore keystore;
+        scriptPubKey = GetScriptForDestination(uncompressedPubkey.GetID());
+
+        // Keystore does not have key
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+        // Keystore has key
+        keystore.AddKey(uncompressedKey);
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+    }
+
+    // P2SH
+    {
+        CBasicKeyStore keystore;
+
+        CScript redeemScript = GetScriptForDestination(pubkeys[0].GetID());
+        scriptPubKey = GetScriptForDestination(CScriptID(redeemScript));
+
+        // Keystore does not have redeemScript or key
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+        // Keystore has redeemScript but no key
+        keystore.AddCScript(redeemScript);
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+        // Keystore has redeemScript and key
+        keystore.AddKey(keys[0]);
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+    }
+
+    // (P2PKH inside) P2SH inside P2SH (invalid)
+    // {
+    //     CBasicKeyStore keystore;
+
+    //     CScript redeemscript_inner = GetScriptForDestination(pubkeys[0].GetID());
+    //     CScript redeemscript = GetScriptForDestination(CScriptID(redeemscript_inner));
+    //     scriptPubKey = GetScriptForDestination(CScriptID(redeemscript));
+
+    //     keystore.AddCScript(redeemscript);
+    //     keystore.AddCScript(redeemscript_inner);
+    //     keystore.AddCScript(scriptPubKey);
+    //     keystore.AddKey(keys[0]);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+    // }
+
+    // (P2PKH inside) P2SH inside P2WSH (invalid)
+    // {
+    //     CBasicKeyStore keystore;
+
+    //     CScript redeemscript = GetScriptForDestination(pubkeys[0].GetID());
+    //     CScript witnessscript = GetScriptForDestination(CScriptID(redeemscript));
+    //     scriptPubKey = GetScriptForDestination(WitnessV0ScriptHash(witnessscript));
+
+    //     keystore.AddCScript(witnessscript);
+    //     keystore.AddCScript(redeemscript);
+    //     keystore.AddCScript(scriptPubKey);
+    //     keystore.AddKey(keys[0]);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+    // }
+
+    // P2WPKH inside P2WSH (invalid)
+    // {
+    //     CBasicKeyStore keystore;
+
+    //     CScript witnessscript = GetScriptForDestination(WitnessV0KeyHash(pubkeys[0].GetID()));
+    //     scriptPubKey = GetScriptForDestination(WitnessV0ScriptHash(witnessscript));
+
+    //     keystore.AddCScript(witnessscript);
+    //     keystore.AddCScript(scriptPubKey);
+    //     keystore.AddKey(keys[0]);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+    // }
+
+    // (P2PKH inside) P2WSH inside P2WSH (invalid)
+    // {
+    //     CBasicKeyStore keystore;
+
+    //     CScript witnessscript_inner = GetScriptForDestination(pubkeys[0].GetID());
+    //     CScript witnessscript = GetScriptForDestination(WitnessV0ScriptHash(witnessscript_inner));
+    //     scriptPubKey = GetScriptForDestination(WitnessV0ScriptHash(witnessscript));
+
+    //     keystore.AddCScript(witnessscript_inner);
+    //     keystore.AddCScript(witnessscript);
+    //     keystore.AddCScript(scriptPubKey);
+    //     keystore.AddKey(keys[0]);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+    // }
+
+    // P2WPKH compressed
+    // {
+    //     CBasicKeyStore keystore;
+    //     keystore.AddKey(keys[0]);
+
+    //     scriptPubKey = GetScriptForDestination(WitnessV0KeyHash(pubkeys[0].GetID()));
+
+    //     // Keystore implicitly has key and P2SH redeemScript
+    //     keystore.AddCScript(scriptPubKey);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+    // }
+
+    // P2WPKH uncompressed
+    // {
+    //     CBasicKeyStore keystore;
+    //     keystore.AddKey(uncompressedKey);
+
+    //     scriptPubKey = GetScriptForDestination(WitnessV0KeyHash(uncompressedPubkey.GetID()));
+
+    //     // Keystore has key, but no P2SH redeemScript
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+    //     // Keystore has key and P2SH redeemScript
+    //     keystore.AddCScript(scriptPubKey);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+    // }
+
+    // scriptPubKey multisig
+    // {
+    //     CBasicKeyStore keystore;
+
+    //     scriptPubKey = GetScriptForMultisig(2, {uncompressedPubkey, pubkeys[1]});
+
+    //     // Keystore does not have any keys
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+    //     // Keystore has 1/2 keys
+    //     keystore.AddKey(uncompressedKey);
+
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+    //     // Keystore has 2/2 keys
+    //     keystore.AddKey(keys[1]);
+
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+    //     // Keystore has 2/2 keys and the script
+    //     keystore.AddCScript(scriptPubKey);
+
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+    // }
+
+    // P2SH multisig
+    {
+        CBasicKeyStore keystore;
+        keystore.AddKey(uncompressedKey);
+        keystore.AddKey(keys[1]);
+
+        CScript redeemScript = GetScriptForMultisig(2, {uncompressedPubkey, pubkeys[1]});
+        scriptPubKey = GetScriptForDestination(CScriptID(redeemScript));
+
+        // Keystore has no redeemScript
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+        // Keystore has redeemScript
+        keystore.AddCScript(redeemScript);
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+    }
+
+    // P2WSH multisig with compressed keys
+    // {
+    //     CBasicKeyStore keystore;
+    //     keystore.AddKey(keys[0]);
+    //     keystore.AddKey(keys[1]);
+
+    //     CScript witnessScript = GetScriptForMultisig(2, {pubkeys[0], pubkeys[1]});
+    //     scriptPubKey = GetScriptForDestination(WitnessV0ScriptHash(witnessScript));
+
+    //     // Keystore has keys, but no witnessScript or P2SH redeemScript
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+    //     // Keystore has keys and witnessScript, but no P2SH redeemScript
+    //     keystore.AddCScript(witnessScript);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+    //     // Keystore has keys, witnessScript, P2SH redeemScript
+    //     keystore.AddCScript(scriptPubKey);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+    // }
+
+    // P2WSH multisig with uncompressed key
+    // {
+    //     CBasicKeyStore keystore;
+    //     keystore.AddKey(uncompressedKey);
+    //     keystore.AddKey(keys[1]);
+
+    //     CScript witnessScript = GetScriptForMultisig(2, {uncompressedPubkey, pubkeys[1]});
+    //     scriptPubKey = GetScriptForDestination(WitnessV0ScriptHash(witnessScript));
+
+    //     // Keystore has keys, but no witnessScript or P2SH redeemScript
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+    //     // Keystore has keys and witnessScript, but no P2SH redeemScript
+    //     keystore.AddCScript(witnessScript);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+    //     // Keystore has keys, witnessScript, P2SH redeemScript
+    //     keystore.AddCScript(scriptPubKey);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+    // }
+
+    // P2WSH multisig wrapped in P2SH
+    // {
+    //     CBasicKeyStore keystore;
+
+    //     CScript witnessScript = GetScriptForMultisig(2, {pubkeys[0], pubkeys[1]});
+    //     CScript redeemScript = GetScriptForDestination(WitnessV0ScriptHash(witnessScript));
+    //     scriptPubKey = GetScriptForDestination(CScriptID(redeemScript));
+
+    //     // Keystore has no witnessScript, P2SH redeemScript, or keys
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+    //     // Keystore has witnessScript and P2SH redeemScript, but no keys
+    //     keystore.AddCScript(redeemScript);
+    //     keystore.AddCScript(witnessScript);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_NO);
+
+    //     // Keystore has keys, witnessScript, P2SH redeemScript
+    //     keystore.AddKey(keys[0]);
+    //     keystore.AddKey(keys[1]);
+    //     result = IsMine(keystore, scriptPubKey);
+    //     BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+    // }
+
+    // OP_RETURN
+    {
+        CBasicKeyStore keystore;
+        keystore.AddKey(keys[0]);
+
+        scriptPubKey.clear();
+        scriptPubKey << OP_RETURN << ToByteVector(pubkeys[0]);
+
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+    }
+
+    // witness unspendable
+    {
+        CBasicKeyStore keystore;
+        keystore.AddKey(keys[0]);
+
+        scriptPubKey.clear();
+        scriptPubKey << OP_0 << ToByteVector(ParseHex("aabb"));
+
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+    }
+
+    // witness unknown
+    {
+        CBasicKeyStore keystore;
+        keystore.AddKey(keys[0]);
+
+        scriptPubKey.clear();
+        scriptPubKey << OP_16 << ToByteVector(ParseHex("aabb"));
+
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+    }
+
+    // Nonstandard
+    {
+        CBasicKeyStore keystore;
+        keystore.AddKey(keys[0]);
+
+        scriptPubKey.clear();
+        scriptPubKey << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
+
+        result = IsMine(keystore, scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -82,6 +82,51 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
     BOOST_CHECK(solutions[3] == ToByteVector(pubkeys[2]));
     BOOST_CHECK(solutions[4] == std::vector<unsigned char>({3}));
 
+    // TX_LOCKED_MULTISIG
+    s.clear();
+    s << 50 << OP_CHECKLOCKTIMEVERIFY << OP_DROP <<
+        OP_1 <<
+        ToByteVector(pubkeys[0]) <<
+        ToByteVector(pubkeys[1]) <<
+        OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_LOCKED_MULTISIG);
+    BOOST_CHECK_EQUAL(solutions.size(), 5U);
+    BOOST_CHECK(solutions[0] == CScriptNum(50).getvch());
+    BOOST_CHECK(solutions[1] == std::vector<unsigned char>({1}));
+    BOOST_CHECK(solutions[2] == ToByteVector(pubkeys[0]));
+    BOOST_CHECK(solutions[3] == ToByteVector(pubkeys[1]));
+    BOOST_CHECK(solutions[4] == std::vector<unsigned char>({2}));
+
+    s.clear();
+    s << 5000 << OP_CHECKLOCKTIMEVERIFY << OP_DROP <<
+        OP_2 <<
+        ToByteVector(pubkeys[0]) <<
+        ToByteVector(pubkeys[1]) <<
+        ToByteVector(pubkeys[2]) <<
+        OP_3 << OP_CHECKMULTISIG;
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_LOCKED_MULTISIG);
+    BOOST_CHECK_EQUAL(solutions.size(), 6U);
+    BOOST_CHECK(solutions[0] == CScriptNum(5000).getvch());
+    BOOST_CHECK(solutions[1] == std::vector<unsigned char>({2}));
+    BOOST_CHECK(solutions[2] == ToByteVector(pubkeys[0]));
+    BOOST_CHECK(solutions[3] == ToByteVector(pubkeys[1]));
+    BOOST_CHECK(solutions[4] == ToByteVector(pubkeys[2]));
+    BOOST_CHECK(solutions[5] == std::vector<unsigned char>({3}));
+
+    s.clear();
+    // test more than 5 bytes in the locktime
+    s << (int64_t)(2UL << 40) << OP_CHECKLOCKTIMEVERIFY << OP_DROP <<
+        OP_2 <<
+        ToByteVector(pubkeys[0]) <<
+        ToByteVector(pubkeys[1]) <<
+        ToByteVector(pubkeys[2]) <<
+        OP_3 << OP_CHECKMULTISIG;
+    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(whichType, TX_NONSTANDARD);
+    BOOST_CHECK_EQUAL(solutions.size(), 0);
+
     // TX_NULL_DATA
     s.clear();
     s << OP_RETURN <<

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2778,6 +2778,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     }
 
+    if (fRequestList) {
+        requestList.RemoveExpired(chainActive.Height() + 1);
+    }
+
     int64_t nTime3 = GetTimeMicros(); nTimeConnect += nTime3 - nTime2;
     LogPrint("bench", "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs]\n", (unsigned)block.vtx.size(), 0.001 * (nTime3 - nTime2), 0.001 * (nTime3 - nTime2) / block.vtx.size(), nInputs <= 1 ? 0 : 0.001 * (nTime3 - nTime2) / (nInputs-1), nTimeConnect * 0.000001);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -87,9 +87,9 @@ bool fRequireWhitelistCheck = DEFAULT_WHITELIST_CHECK;
 bool fScanWhitelist = DEFAULT_SCAN_WHITELIST;
 bool fEnableBurnlistCheck = DEFAULT_BURNLIST_CHECK;
 bool fRequireFreezelistCheck = DEFAULT_BURNLIST_CHECK;
-bool fRequireRequestListCheck = DEFAULT_REQUESTLIST_CHECK;
 bool fblockissuancetx = DEFAULT_BLOCK_ISSUANCE;
 bool fRecordInflation = DEFAULT_RECORD_INFLATION;
+bool fRequestList = DEFAULT_REQUEST_LIST;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
 size_t nCoinCacheUsage = 5000 * 300;
@@ -104,6 +104,7 @@ CAmount maxTxFee = DEFAULT_TRANSACTION_MAXFEE;
 CWhiteList addressWhitelist;
 CPolicyList addressBurnlist;
 CPolicyList addressFreezelist;
+CRequestList requestList;
 
 CTxMemPool mempool(::minRelayTxFee);
 
@@ -2734,7 +2735,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             UpdateAssetMap(tx);
             UpdateFreezeHistory(tx,chainActive.Height()+1);
         }
-        
+
+        if (fRequestList) {
+            if(tx.vout[0].nAsset.GetAsset() == permissionAsset) UpdateRequestList(tx,view);
+        }
+
         // GetTransactionSigOpCost counts 3 types of sigops:
         // * legacy (always)
         // * p2sh (when P2SH enabled in flags and excludes coinbase)

--- a/src/validation.h
+++ b/src/validation.h
@@ -222,6 +222,7 @@ extern bool fRequireRequestListCheck;
 extern bool fEnableBurnlistCheck;
 extern bool fblockissuancetx;
 extern bool fRecordInflation;
+extern bool fRequestList;
 extern bool fRequireStandard;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;

--- a/src/validation.h
+++ b/src/validation.h
@@ -23,6 +23,7 @@
 #include "util.h"
 #include "policy/whitelist.h"
 #include "policy/policylist.h"
+#include "policy/requestlist.h"
 
 #include <algorithm>
 #include <exception>
@@ -139,8 +140,8 @@ static const bool DEFAULT_SCAN_WHITELIST = false;
 static const bool DEFAULT_BLOCK_ISSUANCE = false;
 static const bool DEFAULT_BURNLIST_CHECK = false;
 static const bool DEFAULT_FREEZELIST_CHECK = false;
-static const bool DEFAULT_REQUESTLIST_CHECK = false;
 static const bool DEFAULT_RECORD_INFLATION = false;
+static const bool DEFAULT_REQUEST_LIST = false;
 
 /** Default for -permitbaremultisig */
 static const bool DEFAULT_PERMIT_BAREMULTISIG = true;
@@ -169,6 +170,8 @@ extern CWhiteList addressWhitelist;
 extern CPolicyList addressFreezelist;
 //burnlist address list
 extern CPolicyList addressBurnlist;
+//request list
+extern CRequestList requestList;
 
 struct IssuanceData
 {
@@ -441,7 +444,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fChe
 namespace Consensus {
 
 /**
-* Check wether the bitcoin address is derived from the public key via key tweaking 
+* Check wether the bitcoin address is derived from the public key via key tweaking
 * using the hash contract of the chain active tip.
 */
 bool CheckValidTweakedAddress(const  CKeyID& keyID, const CPubKey& pubKey);


### PR DESCRIPTION
- ported standard refactoring from bitcoin
https://github.com/bitcoin/bitcoin/pull/13194

- ported scripts_standard test
https://github.com/bitcoin/bitcoin/blob/master/src/test/script_standard_tests.cpp
I've commented stuff to do with witness refactoring and also bare multisig not being standard in bitcoin.

- new tx type TX_LOCKED_MULTISIG (#104)
- Solver handling for TX_LOCKED_MULTISIG (#104)
- sign handling for TX_LOCKED_MULTISIG (#104)
- end to end `requests.py` test: create raw request, fetch requests, spend previously locked request on expiry
- add Request class and FromSolutions constructor
- added Request list and add/remove/update on init and connect block