### PR TITLE
added zero address exception to iswhitelisted

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -188,6 +188,9 @@ bool IsPolicy(const CAsset& asset){
 bool IsWhitelisted(CTransaction const &tx) {
   CKeyID keyId;
   txnouttype whichType;
+
+  uint160 frzInt;
+  frzInt.SetHex("0x0000000000000000000000000000000000000000");
   for (CTxOut const &txout : tx.vout) {
     vector<vector<uint8_t>> vSolutions;
     if (!Solver(txout.scriptPubKey, whichType, vSolutions))
@@ -207,7 +210,7 @@ bool IsWhitelisted(CTransaction const &tx) {
     keyId = CKeyID(uint160(vSolutions[0]));
     // Search in whitelist for the presence of each output address.
     // If one is not found, return false.
-    if (!addressWhitelist.is_whitelisted(keyId))
+    if (!addressWhitelist.is_whitelisted(keyId) && uint160(vSolutions[0]) != frzInt)
       return false;
   }
   return true;


### PR DESCRIPTION
The 'zero address' (P2PKH) is used as a flag for a redemption transaction - it does not need to be checked that it is on the whitelist (but the other outputs in the same transaction do). 

I will add a test for this. 