### PR TITLE
HF: Several changes to policy assets and getrawtransaction rpc

### DIFF
--- a/qa/rpc-tests/onboard.py
+++ b/qa/rpc-tests/onboard.py
@@ -97,10 +97,11 @@ class OnboardTest (BitcoinTestFramework):
                 paasset = rawtx["vout"][0]["asset"]
                 patxid = txid
                 pavalue = rawtx["vout"][0]["value"]
-            if rawtx["vout"][0]["scriptPubKey"]["hex"] == wlscript:
-                wlasset = rawtx["vout"][0]["asset"]
-                wltxid = txid
-                wlvalue = rawtx["vout"][0]["value"]
+            if "assetlabel" in rawtx["vout"][0]:
+                if rawtx["vout"][0]["assetlabel"] == "WHITELIST":
+                    wlasset = rawtx["vout"][0]["asset"]
+                    wltxid = txid
+                    wlvalue = rawtx["vout"][0]["value"]
 
         #Whitelist node 0 addresses
         self.nodes[0].dumpderivedkeys("keys.main")

--- a/qa/rpc-tests/onboard.py
+++ b/qa/rpc-tests/onboard.py
@@ -20,24 +20,30 @@ class OnboardTest (BitcoinTestFramework):
         self.extra_args[0].append("-burnlist=1")
         self.extra_args[0].append("-pkhwhitelist=1")
         self.extra_args[0].append("-rescan=1")
-        self.extra_args[0].append("-initialfreecoins=50000000000000")
+        self.extra_args[0].append("-initialfreecoins=2100000000000000")
+        self.extra_args[0].append("-policycoins=50000000000000")
         self.extra_args[0].append("-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[0].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
         self.extra_args[0].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
         self.extra_args[0].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
         self.extra_args[0].append("-whitelistcoinsdestination=76a914427bf8530a3962ed77fd3c07d17fd466cb31c2fd88ac")
         self.extra_args[1].append("-rescan=1")
         self.extra_args[1].append("-pkhwhitelist-scan=1")
         self.extra_args[1].append("-keypool=100")
-        self.extra_args[1].append("-initialfreecoins=50000000000000")
+        self.extra_args[1].append("-initialfreecoins=2100000000000000")
+        self.extra_args[1].append("-policycoins=50000000000000")
         self.extra_args[1].append("-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[1].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
         self.extra_args[1].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
         self.extra_args[1].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
         self.extra_args[1].append("-whitelistcoinsdestination=76a914427bf8530a3962ed77fd3c07d17fd466cb31c2fd88ac")
         self.extra_args[2].append("-rescan=1")
-        self.extra_args[1].append("-pkhwhitelist-scan=1")
+        self.extra_args[2].append("-pkhwhitelist-scan=1")
         self.extra_args[2].append("-keypool=100")
-        self.extra_args[2].append("-initialfreecoins=50000000000000")
+        self.extra_args[2].append("-initialfreecoins=2100000000000000")
+        self.extra_args[2].append("-policycoins=50000000000000")
         self.extra_args[2].append("-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[2].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
         self.extra_args[2].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
         self.extra_args[2].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
         self.extra_args[2].append("-whitelistcoinsdestination=76a914427bf8530a3962ed77fd3c07d17fd466cb31c2fd88ac")
@@ -153,13 +159,14 @@ class OnboardTest (BitcoinTestFramework):
         nwhitelisted=keypool
 
         #Send some tokens to node 1
-        ntosend=100.234
+        ntosend=10000.234
         self.nodes[0].sendtoaddress(node1addr, ntosend)
+        self.nodes[0].sendtoaddress(node1addr, ntosend, "", "", False, paasset)
 
         self.nodes[0].generate(101)
         self.sync_all()
 
-        bal1=self.nodes[1].getwalletinfo()["balance"]["CBT"]
+        bal1=self.nodes[1].getwalletinfo()["balance"]["ISSUANCE"]
 
         assert_equal(float(bal1),float(ntosend))
 
@@ -178,7 +185,7 @@ class OnboardTest (BitcoinTestFramework):
         # wl1file_2="wl1_2.dat"
         # self.nodes[1].dumpwhitelist(wl1file_2)
         # assert(filecmp.cmp(wlfile, wlfile_2))
-
+ 
         #Node 1 registers additional addresses to whitelist
         nadd=100
         self.nodes[1].sendaddtowhitelisttx(nadd,"CBT")

--- a/qa/rpc-tests/policytransactions.py
+++ b/qa/rpc-tests/policytransactions.py
@@ -94,7 +94,8 @@ class PolicyTransactionTest (BitcoinTestFramework):
         outp = {}
         outp[fundaddr] = 4999.999
         outp["fee"] = 0.001
-        fundtx = self.nodes[0].createrawtransaction(inputs,outp)
+        assets = {addr: paasset}
+        fundtx = self.nodes[0].createrawtransaction(inputs,outp,0,assets)
         fundtx_signed = self.nodes[0].signrawtransaction(fundtx)
         assert(fundtx_signed["complete"])
         fundtx_send = self.nodes[0].sendrawtransaction(fundtx_signed["hex"])

--- a/qa/rpc-tests/policytransactions.py
+++ b/qa/rpc-tests/policytransactions.py
@@ -60,18 +60,19 @@ class PolicyTransactionTest (BitcoinTestFramework):
 
         for txid in genblock["tx"]:
             rawtx = self.nodes[0].getrawtransaction(txid,True)
-            if rawtx["vout"][0]["scriptPubKey"]["hex"] == flscript:
-                flasset = rawtx["vout"][0]["asset"]
-                fltxid = txid
-                flvalue = rawtx["vout"][0]["value"]
-            if rawtx["vout"][0]["scriptPubKey"]["hex"] == blscript:
-                blasset = rawtx["vout"][0]["asset"]
-                bltxid = txid
-                blvalue = rawtx["vout"][0]["value"]
-            if rawtx["vout"][0]["scriptPubKey"]["hex"] == pascript:
-                paasset = rawtx["vout"][0]["asset"]
-                patxid = txid
-                pavalue = rawtx["vout"][0]["value"]
+            if "assetlabel" in rawtx["vout"][0]:
+                if rawtx["vout"][0]["assetlabel"] == "FREEZELIST":
+                    flasset = rawtx["vout"][0]["asset"]
+                    fltxid = txid
+                    flvalue = rawtx["vout"][0]["value"]
+                if rawtx["vout"][0]["assetlabel"] == "BURNLIST":
+                    blasset = rawtx["vout"][0]["asset"]
+                    bltxid = txid
+                    blvalue = rawtx["vout"][0]["value"]
+                if rawtx["vout"][0]["assetlabel"] == "ISSUANCE":
+                    paasset = rawtx["vout"][0]["asset"]
+                    patxid = txid
+                    pavalue = rawtx["vout"][0]["value"]
 
         #issue some non-policy asset
         assaddr = self.nodes[0].getnewaddress()

--- a/qa/rpc-tests/policytransactions.py
+++ b/qa/rpc-tests/policytransactions.py
@@ -19,15 +19,15 @@ class PolicyTransactionTest (BitcoinTestFramework):
         self.extra_args[1].append("-burnlist=1")
         self.extra_args[2].append("-freezelist=1")
         self.extra_args[2].append("-burnlist=1")
-        self.extra_args[0].append("-initialfreecoins=50000000000000")
+        self.extra_args[0].append("-policycoins=50000000000000")
         self.extra_args[0].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
         self.extra_args[0].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
         self.extra_args[0].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
-        self.extra_args[1].append("-initialfreecoins=50000000000000")
+        self.extra_args[1].append("-policycoins=50000000000000")
         self.extra_args[1].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
         self.extra_args[1].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
         self.extra_args[1].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
-        self.extra_args[2].append("-initialfreecoins=50000000000000")
+        self.extra_args[2].append("-policycoins=50000000000000")
         self.extra_args[2].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
         self.extra_args[2].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
         self.extra_args[2].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
@@ -94,7 +94,9 @@ class PolicyTransactionTest (BitcoinTestFramework):
         outp = {}
         outp[fundaddr] = 4999.999
         outp["fee"] = 0.001
-        assets = {fundaddr: paasset}
+        assets =  {}
+        assets[fundaddr] = paasset;
+        assets["fee"] = paasset;
         fundtx = self.nodes[0].createrawtransaction(inputs,outp,0,assets)
         fundtx_signed = self.nodes[0].signrawtransaction(fundtx)
         assert(fundtx_signed["complete"])

--- a/qa/rpc-tests/policytransactions.py
+++ b/qa/rpc-tests/policytransactions.py
@@ -60,19 +60,18 @@ class PolicyTransactionTest (BitcoinTestFramework):
 
         for txid in genblock["tx"]:
             rawtx = self.nodes[0].getrawtransaction(txid,True)
-            if "assetlabel" in rawtx["vout"][0]:
-                if rawtx["vout"][0]["assetlabel"] == "FREEZELIST":
-                    flasset = rawtx["vout"][0]["asset"]
-                    fltxid = txid
-                    flvalue = rawtx["vout"][0]["value"]
-                if rawtx["vout"][0]["assetlabel"] == "BLACKLIST":
-                    blasset = rawtx["vout"][0]["asset"]
-                    bltxid = txid
-                    blvalue = rawtx["vout"][0]["value"]
-                if rawtx["vout"][0]["assetlabel"] == "ISSUANCE":
-                    paasset = rawtx["vout"][0]["asset"]
-                    patxid = txid
-                    pavalue = rawtx["vout"][0]["value"]
+            if rawtx["vout"][0]["assetlabel"] == flscript:
+                flasset = rawtx["vout"][0]["asset"]
+                fltxid = txid
+                flvalue = rawtx["vout"][0]["value"]
+            if rawtx["vout"][0]["scriptPubKey"]["hex"] == blscript:
+                blasset = rawtx["vout"][0]["asset"]
+                bltxid = txid
+                blvalue = rawtx["vout"][0]["value"]
+            if rawtx["vout"][0]["scriptPubKey"]["hex"] == pascript:
+                paasset = rawtx["vout"][0]["asset"]
+                patxid = txid
+                pavalue = rawtx["vout"][0]["value"]
 
         #issue some non-policy asset
         assaddr = self.nodes[0].getnewaddress()

--- a/qa/rpc-tests/policytransactions.py
+++ b/qa/rpc-tests/policytransactions.py
@@ -94,7 +94,7 @@ class PolicyTransactionTest (BitcoinTestFramework):
         outp = {}
         outp[fundaddr] = 4999.999
         outp["fee"] = 0.001
-        assets = {addr: paasset}
+        assets = paasset
         fundtx = self.nodes[0].createrawtransaction(inputs,outp,0,assets)
         fundtx_signed = self.nodes[0].signrawtransaction(fundtx)
         assert(fundtx_signed["complete"])

--- a/qa/rpc-tests/policytransactions.py
+++ b/qa/rpc-tests/policytransactions.py
@@ -20,15 +20,15 @@ class PolicyTransactionTest (BitcoinTestFramework):
         self.extra_args[2].append("-freezelist=1")
         self.extra_args[2].append("-burnlist=1")
         self.extra_args[0].append("-initialfreecoins=50000000000000")
-        self.extra_args[0].append("-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[0].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
         self.extra_args[0].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
         self.extra_args[0].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
         self.extra_args[1].append("-initialfreecoins=50000000000000")
-        self.extra_args[1].append("-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[1].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
         self.extra_args[1].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
         self.extra_args[1].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
         self.extra_args[2].append("-initialfreecoins=50000000000000")
-        self.extra_args[2].append("-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[2].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
         self.extra_args[2].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
         self.extra_args[2].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
 
@@ -60,18 +60,19 @@ class PolicyTransactionTest (BitcoinTestFramework):
 
         for txid in genblock["tx"]:
             rawtx = self.nodes[0].getrawtransaction(txid,True)
-            if rawtx["vout"][0]["scriptPubKey"]["hex"] == flscript:
-                flasset = rawtx["vout"][0]["asset"]
-                fltxid = txid
-                flvalue = rawtx["vout"][0]["value"]
-            if rawtx["vout"][0]["scriptPubKey"]["hex"] == blscript:
-                blasset = rawtx["vout"][0]["asset"]
-                bltxid = txid
-                blvalue = rawtx["vout"][0]["value"]
-            if rawtx["vout"][0]["scriptPubKey"]["hex"] == pascript:
-                paasset = rawtx["vout"][0]["asset"]
-                patxid = txid
-                pavalue = rawtx["vout"][0]["value"]
+            if "assetlabel" in rawtx["vout"][0]:
+                if rawtx["vout"][0]["assetlabel"] == "FREEZELIST":
+                    flasset = rawtx["vout"][0]["asset"]
+                    fltxid = txid
+                    flvalue = rawtx["vout"][0]["value"]
+                if rawtx["vout"][0]["assetlabel"] == "BLACKLIST":
+                    blasset = rawtx["vout"][0]["asset"]
+                    bltxid = txid
+                    blvalue = rawtx["vout"][0]["value"]
+                if rawtx["vout"][0]["assetlabel"] == "ISSUANCE":
+                    paasset = rawtx["vout"][0]["asset"]
+                    patxid = txid
+                    pavalue = rawtx["vout"][0]["value"]
 
         #issue some non-policy asset
         assaddr = self.nodes[0].getnewaddress()

--- a/qa/rpc-tests/policytransactions.py
+++ b/qa/rpc-tests/policytransactions.py
@@ -60,7 +60,7 @@ class PolicyTransactionTest (BitcoinTestFramework):
 
         for txid in genblock["tx"]:
             rawtx = self.nodes[0].getrawtransaction(txid,True)
-            if rawtx["vout"][0]["assetlabel"] == flscript:
+            if rawtx["vout"][0]["scriptPubKey"]["hex"] == flscript:
                 flasset = rawtx["vout"][0]["asset"]
                 fltxid = txid
                 flvalue = rawtx["vout"][0]["value"]

--- a/qa/rpc-tests/policytransactions.py
+++ b/qa/rpc-tests/policytransactions.py
@@ -94,7 +94,7 @@ class PolicyTransactionTest (BitcoinTestFramework):
         outp = {}
         outp[fundaddr] = 4999.999
         outp["fee"] = 0.001
-        assets = paasset
+        assets = {fundaddr: paasset}
         fundtx = self.nodes[0].createrawtransaction(inputs,outp,0,assets)
         fundtx_signed = self.nodes[0].signrawtransaction(fundtx)
         assert(fundtx_signed["complete"])

--- a/qa/rpc-tests/raw_issuance.py
+++ b/qa/rpc-tests/raw_issuance.py
@@ -13,6 +13,15 @@ class RawIssuance (BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 4
         self.extra_args = [['-issuanceblock'] for i in range(4)]
+        self.extra_args[0].append("-txindex")
+        self.extra_args[0].append("-policycoins=50000000000000")
+        self.extra_args[0].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[1].append("-txindex")
+        self.extra_args[1].append("-policycoins=50000000000000")
+        self.extra_args[1].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[2].append("-txindex")
+        self.extra_args[2].append("-policycoins=50000000000000")
+        self.extra_args[2].append("-issuancecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
 
     def setup_network(self, split=False):
         self.nodes = start_nodes(3, self.options.tmpdir, self.extra_args[:3])
@@ -29,12 +38,28 @@ class RawIssuance (BitcoinTestFramework):
         assert_equal(len(self.nodes[1].listunspent()), 100)
         assert_equal(len(self.nodes[2].listunspent()), 100)
 
-        walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['balance']["CBT"], 21000000)
+        self.nodes[2].importprivkey("cTnxkovLhGbp7VRhMhGThYt8WDwviXgaVAD8DjaVa5G5DApwC6tF")
+
+        walletinfo = self.nodes[2].getbalance()
+        assert_equal(walletinfo["CBT"], 21000000)
+        assert_equal(walletinfo["ISSUANCE"], 500000)
 
         print("Mining blocks...")
         self.nodes[1].generate(101)
         self.sync_all()
+
+        asscript = "76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac";
+
+        genhash = self.nodes[2].getblockhash(0)
+        genblock = self.nodes[2].getblock(genhash)
+
+        for txid in genblock["tx"]:
+            rawtx = self.nodes[2].getrawtransaction(txid,True)
+            if "assetlabel" in rawtx["vout"][0]:
+                if rawtx["vout"][0]["assetlabel"] == "ISSUANCE":
+                    asasset = rawtx["vout"][0]["asset"]
+                    astxid = txid
+                    asvalue = rawtx["vout"][0]["value"]
 
         assert_equal(self.nodes[0].getbalance("", 0, False, "CBT"), 21000000)
         assert_equal(self.nodes[1].getbalance("", 0, False, "CBT"), 21000000)
@@ -66,7 +91,7 @@ class RawIssuance (BitcoinTestFramework):
         #create 2 of 3 multisig P2SH script and address                                 
         multisig = self.nodes[0].createmultisig(2,[val_addr_node1["pubkey"],val_addr_node2["pubkey"],val_addr_node3["pubkey"]])
         #send some policyasset to the P2SH address
-        pa_txid = self.nodes[0].sendtoaddress(multisig["address"],1)
+        pa_txid = self.nodes[2].sendtoaddress(multisig["address"],1,"","",False,asasset)
         self.nodes[1].generate(1)
         self.sync_all()
 

--- a/qa/rpc-tests/request-auction.py
+++ b/qa/rpc-tests/request-auction.py
@@ -8,7 +8,7 @@ class RequestAuctionTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 4
-        self.extra_args = [["-txindex=1 -initialfreecoins=50000000000000",
+        self.extra_args = [["-txindex=1 -initialfreecoins=50000000000000", "-policycoins=50000000000000",
         "-permissioncoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac",
         "-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac"] for i in range(4)]
         self.extra_args[0].append("-requestlist=1")

--- a/qa/rpc-tests/request-bids.py
+++ b/qa/rpc-tests/request-bids.py
@@ -82,6 +82,18 @@ class RequestbidsTest(BitcoinTestFramework):
     assert_equal(pubkeyFee, request_bids['bids'][0]['feePubKey'])
     assert_equal(genesis, request_bids['genesisBlock'])
 
+
+    fulltr = self.nodes[1].getrawtransaction(txid, True)
+    foundBid = False
+    for tout in fulltr['vout']:
+        if "bid" in tout:
+            rawbid = tout["bid"]
+            if (rawbid['txid'] == request_bids['bids'][0]['txid']):
+                assert_equal(request_bids['bids'][0]['feePubKey'], rawbid['feePubKey'])
+                foundBid = True
+                break
+    assert(foundBid)
+
     #test stopping and restarting to make sure list is reloaded
     self.stop_node(1)
     self.nodes[1] = start_node(1, self.options.tmpdir, self.extra_args[1])

--- a/qa/rpc-tests/request-bids.py
+++ b/qa/rpc-tests/request-bids.py
@@ -8,7 +8,7 @@ class RequestbidsTest(BitcoinTestFramework):
     super().__init__()
     self.setup_clean_chain = True
     self.num_nodes = 2
-    self.extra_args = [["-txindex=1 -initialfreecoins=50000000000000",
+    self.extra_args = [["-txindex=1 -initialfreecoins=50000000000000", "-policycoins=50000000000000",
     "-permissioncoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac",
     "-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac"] for i in range(2)]
     self.extra_args[1].append("-requestlist=1")

--- a/qa/rpc-tests/requests.py
+++ b/qa/rpc-tests/requests.py
@@ -8,7 +8,7 @@ class RequestsTest(BitcoinTestFramework):
     super().__init__()
     self.setup_clean_chain = True
     self.num_nodes = 2
-    self.extra_args = [["-txindex=1 -initialfreecoins=50000000000000",
+    self.extra_args = [["-txindex=1 -initialfreecoins=50000000000000", "-policycoins=50000000000000",
     "-permissioncoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac",
     "-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac"] for i in range(2)]
     self.extra_args[1].append("-requestlist=1")

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -39,17 +39,18 @@ class WalletTest (BitcoinTestFramework):
 
     def run_test (self):
 
+        self.nodes[2].importprivkey("cTnxkovLhGbp7VRhMhGThYt8WDwviXgaVAD8DjaVa5G5DApwC6tF")
+
         # Check that there's 100 UTXOs on each of the nodes
         assert_equal(len(self.nodes[0].listunspent()), 100)
         assert_equal(len(self.nodes[1].listunspent()), 100)
-        assert_equal(len(self.nodes[2].listunspent()), 100)
+        assert_equal(len(self.nodes[2].listunspent()), 200)
 
-        self.nodes[2].importprivkey("cS29UJMQrpnee7UaUHo6NqJVpGr35TEqUDkKXStTnxSZCGUWavgE")
-        self.nodes[2].importprivkey("cND4nfH6g2SopoLk5isQ8qGqqZ5LmbK6YwJ1QnyoyMVBTs8bVNNd")
-        self.nodes[2].importprivkey("cTnxkovLhGbp7VRhMhGThYt8WDwviXgaVAD8DjaVa5G5DApwC6tF")
+        
 
-        walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['balance']["CBT"], 21000000)
+        walletinfo = self.nodes[2].getbalance()
+        assert_equal(walletinfo["CBT"], 21000000)
+        assert_equal(walletinfo["ISSUANCE"], 500000)
 
         print("Mining blocks...")
         self.nodes[2].generate(101)
@@ -62,10 +63,11 @@ class WalletTest (BitcoinTestFramework):
 
         for txid in genblock["tx"]:
             rawtx = self.nodes[2].getrawtransaction(txid,True)
-            if rawtx["vout"][0]["scriptPubKey"]["hex"] == asscript:
-                asasset = rawtx["vout"][0]["asset"]
-                astxid = txid
-                asvalue = rawtx["vout"][0]["value"]
+            if "assetlabel" in rawtx["vout"][0]:
+                if rawtx["vout"][0]["assetlabel"] == "ISSUANCE":
+                    asasset = rawtx["vout"][0]["asset"]
+                    astxid = txid
+                    asvalue = rawtx["vout"][0]["value"]
 
         assert_equal(self.nodes[0].getbalance("", 0, False, "CBT"), 21000000)
         assert_equal(self.nodes[1].getbalance("", 0, False, "CBT"), 21000000)

--- a/src/assetsdir.cpp
+++ b/src/assetsdir.cpp
@@ -65,6 +65,9 @@ void CAssetsDir::InitFromStrings(const std::vector<std::string>& assetsToInit)
     if (Params().GetConsensus().permission_asset != CAsset()) {
         Set(Params().GetConsensus().permission_asset, AssetMetadata("PERMISSION"));
     }
+    if (Params().GetConsensus().issuance_asset != CAsset()) {
+        Set(Params().GetConsensus().issuance_asset, AssetMetadata("ISSUANCE"));
+    }
 }
 
 CAsset CAssetsDir::GetAsset(const std::string& label) const

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -155,6 +155,7 @@ protected:
         whiteListCoinsDestination = StrHexToScriptWithDefault(GetArg("-whitelistcoinsdestination", ""), CScript() << OP_RETURN);
         challengeCoinsDestination = StrHexToScriptWithDefault(GetArg("-challengecoinsdestination", ""), CScript() << OP_RETURN);
         permissionCoinsDestination = StrHexToScriptWithDefault(GetArg("-permissioncoinsdestination", ""), CScript() << OP_RETURN);
+        issuanceCoinsDestination = StrHexToScriptWithDefault(GetArg("-issuancecoinsdestination", ""), CScript() << OP_RETURN);
         attestationHash = uint256S(GetArg("-attestationhash", ""));
 
         nDefaultPort = GetArg("-ndefaultport", 7042);
@@ -261,6 +262,17 @@ public:
                 CalculateAsset(consensus.permission_asset, entropy);
 
                 AppendInitialIssuance(genesis, prevout, contract, 100, initialFreeCoins / 100, 0, 0, permissionCoinsDestination);
+            }
+
+            if (!issuanceCoinsDestination.IsUnspendable()) {
+                uint256 contract = uint256S("0000000000000000000000000000000000000000000000000000000000000060");
+                const COutPoint prevout = COutPoint(uint256(commit), nOut);
+                ++nOut;
+
+                GenerateAssetEntropy(entropy, prevout, contract);
+                CalculateAsset(consensus.issuance_asset, entropy);
+
+                AppendInitialIssuance(genesis, prevout, contract, 100, initialFreeCoins / 100, 0, 0, issuanceCoinsDestination);
             }
         }
         consensus.hashGenesisBlock = genesis.GetHash();

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -149,6 +149,7 @@ protected:
         // bitcoin regtest is the parent chain by default
         parentGenesisBlockHash = uint256S(GetArg("-parentgenesisblockhash", "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
         initialFreeCoins = GetArg("-initialfreecoins", 0);
+        policyCoins = GetArg("-policycoins", 0);
         initialFreeCoinsDestination = StrHexToScriptWithDefault(GetArg("-initialfreecoinsdestination", ""), CScript() << OP_TRUE);
         freezeListCoinsDestination = StrHexToScriptWithDefault(GetArg("-freezelistcoinsdestination", ""), CScript() << OP_RETURN);
         burnListCoinsDestination = StrHexToScriptWithDefault(GetArg("-burnlistcoinsdestination", ""), CScript() << OP_RETURN);
@@ -205,10 +206,13 @@ public:
         CalculateAsset(consensus.pegged_asset, entropy);
 
         genesis = CreateGenesisBlock(consensus, strNetworkID, 1514764800, genesisChallengeScript, 1);
+        int nOut = 0;
         if (initialFreeCoins != 0) {
-            AppendInitialIssuance(genesis, COutPoint(uint256(commit), 0), parentGenesisBlockHash, 100, initialFreeCoins/100, 0, 0, initialFreeCoinsDestination);
+            AppendInitialIssuance(genesis, COutPoint(uint256(commit), nOut), parentGenesisBlockHash, 100, initialFreeCoins/100, 0, 0, initialFreeCoinsDestination);
+            ++nOut;
+        }
 
-            int nOut = 1;
+        if (policyCoins != 0) {
             if(!freezeListCoinsDestination.IsUnspendable()) {
                 uint256 contract = uint256S("0000000000000000000000000000000000000000000000000000000000000010");
                 const COutPoint prevout = COutPoint(uint256(commit), nOut);
@@ -217,7 +221,7 @@ public:
                 GenerateAssetEntropy(entropy,  prevout, contract);
                 CalculateAsset(consensus.freezelist_asset, entropy);
 
-                AppendInitialIssuance(genesis, prevout, contract, 100, initialFreeCoins/100, 0, 0, freezeListCoinsDestination);
+                AppendInitialIssuance(genesis, prevout, contract, 100, policyCoins/100, 0, 0, freezeListCoinsDestination);
             }
 
             if(!burnListCoinsDestination.IsUnspendable()) {
@@ -228,7 +232,7 @@ public:
                 GenerateAssetEntropy(entropy,  prevout, contract);
                 CalculateAsset(consensus.burnlist_asset, entropy);
 
-                AppendInitialIssuance(genesis, prevout, contract, 100, initialFreeCoins/100, 0, 0, burnListCoinsDestination);
+                AppendInitialIssuance(genesis, prevout, contract, 100, policyCoins/100, 0, 0, burnListCoinsDestination);
             }
 
             if(!whiteListCoinsDestination.IsUnspendable()) {
@@ -239,7 +243,7 @@ public:
                 GenerateAssetEntropy(entropy,  prevout, contract);
                 CalculateAsset(consensus.whitelist_asset, entropy);
 
-                AppendInitialIssuance(genesis, prevout, contract, 100, initialFreeCoins/100, 0, 0, whiteListCoinsDestination);
+                AppendInitialIssuance(genesis, prevout, contract, 100, policyCoins/100, 0, 0, whiteListCoinsDestination);
             }
 
             if(!challengeCoinsDestination.IsUnspendable()) {
@@ -250,7 +254,7 @@ public:
                 GenerateAssetEntropy(entropy,  prevout, contract);
                 CalculateAsset(consensus.challenge_asset, entropy);
 
-                AppendInitialIssuance(genesis, prevout, contract, 100, initialFreeCoins/100, 0, 0, challengeCoinsDestination);
+                AppendInitialIssuance(genesis, prevout, contract, 100, policyCoins/100, 0, 0, challengeCoinsDestination);
             }
 
             if (!permissionCoinsDestination.IsUnspendable()) {
@@ -261,7 +265,7 @@ public:
                 GenerateAssetEntropy(entropy, prevout, contract);
                 CalculateAsset(consensus.permission_asset, entropy);
 
-                AppendInitialIssuance(genesis, prevout, contract, 100, initialFreeCoins / 100, 0, 0, permissionCoinsDestination);
+                AppendInitialIssuance(genesis, prevout, contract, 100, policyCoins / 100, 0, 0, permissionCoinsDestination);
             }
 
             if (!issuanceCoinsDestination.IsUnspendable()) {
@@ -272,9 +276,10 @@ public:
                 GenerateAssetEntropy(entropy, prevout, contract);
                 CalculateAsset(consensus.issuance_asset, entropy);
 
-                AppendInitialIssuance(genesis, prevout, contract, 100, initialFreeCoins / 100, 0, 0, issuanceCoinsDestination);
+                AppendInitialIssuance(genesis, prevout, contract, 100, policyCoins / 100, 0, 0, issuanceCoinsDestination);
             }
         }
+
         consensus.hashGenesisBlock = genesis.GetHash();
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -121,6 +121,7 @@ protected:
     CScript whiteListCoinsDestination;
     CScript challengeCoinsDestination;
     CScript permissionCoinsDestination;
+    CScript issuanceCoinsDestination;
     std::vector<SeedSpec6> vFixedSeeds;
     bool fMiningRequiresPeers;
     bool fDefaultConsistencyChecks;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -112,9 +112,10 @@ protected:
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
     std::string strNetworkID;
     CBlock genesis;
-    uint256 parentGenesisBlockHash;
+    uint256 parentGenesisBlockHash; 
     uint256 attestationHash;
     CAmount initialFreeCoins;
+    CAmount policyCoins;
     CScript initialFreeCoinsDestination;
     CScript freezeListCoinsDestination;
     CScript burnListCoinsDestination;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -73,6 +73,7 @@ struct Params {
     CAsset whitelist_asset;
     CAsset challenge_asset;
     CAsset permission_asset;
+    CAsset issuance_asset;
 
     uint256 defaultAssumeValid;
     uint32_t pegin_min_depth;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -527,6 +527,7 @@ std::string HelpMessage(HelpMessageMode mode)
             " " + _(" This creates a new chain with a different genesis block."));
         strUsage += HelpMessageOpt("-peginconfirmationdepth", strprintf(_("Pegin claims must be this deep to be considered valid. (default: %d)"), DEFAULT_PEGIN_CONFIRMATION_DEPTH));
         strUsage += HelpMessageOpt("-initialfreecoins", strprintf(_("The amount of OP_TRUE coins created in the genesis block. Primarily for testing. (default: %d)"), 0));
+        strUsage += HelpMessageOpt("-policycoins", strprintf(_("The amount of policy coins created in the genesis block. Primarily for testing. (default: %d)"), 0));
         strUsage += HelpMessageOpt("-initialfreecoinsdestination", strprintf(_("The destination of the OP_TRUE coins created in the genesis block. Primarily for testing. (default: %d)"), 0));
         strUsage += HelpMessageOpt("-freezelistcoinsdestination", strprintf(_("The destination of the tokens for controlling the freezelist (default: %d)"), 0));
         strUsage += HelpMessageOpt("-burnlistcoinsdestination", strprintf(_("The destination of the tokens for controlling the burnlist. (default: %d)"), 0));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -527,7 +527,7 @@ std::string HelpMessage(HelpMessageMode mode)
             " " + _(" This creates a new chain with a different genesis block."));
         strUsage += HelpMessageOpt("-peginconfirmationdepth", strprintf(_("Pegin claims must be this deep to be considered valid. (default: %d)"), DEFAULT_PEGIN_CONFIRMATION_DEPTH));
         strUsage += HelpMessageOpt("-initialfreecoins", strprintf(_("The amount of OP_TRUE coins created in the genesis block. Primarily for testing. (default: %d)"), 0));
-        strUsage += HelpMessageOpt("-policycoins", strprintf(_("The amount of policy coins created in the genesis block. Primarily for testing. (default: %d)"), 0));
+        strUsage += HelpMessageOpt("-policycoins", strprintf(_("The amount of policy coins created in the genesis block. (default: %d)"), 0));
         strUsage += HelpMessageOpt("-initialfreecoinsdestination", strprintf(_("The destination of the OP_TRUE coins created in the genesis block. Primarily for testing. (default: %d)"), 0));
         strUsage += HelpMessageOpt("-freezelistcoinsdestination", strprintf(_("The destination of the tokens for controlling the freezelist (default: %d)"), 0));
         strUsage += HelpMessageOpt("-burnlistcoinsdestination", strprintf(_("The destination of the tokens for controlling the burnlist. (default: %d)"), 0));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -533,6 +533,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-whitelistcoinsdestination", strprintf(_("The destination of the tokens for controlling the whitelist. (default: %d)"), 0));
         strUsage += HelpMessageOpt("-challengecoinsdestination", strprintf(_("The destination of the tokens for issuing guardnode challenges. (default: %d)"), 0));
         strUsage += HelpMessageOpt("-permissioncoinsdestination", strprintf(_("The destination of the tokens for permitting request creation. (default: %d)"), 0));
+        strUsage += HelpMessageOpt("-issuancecoinsdestination", strprintf(_("The destination of the issued tokens. (default: %d)"), 0));
     }
     strUsage += HelpMessageOpt("-validatepegin", strprintf(_("Validate pegin claims. All functionaries must run this. (default: %u)"), DEFAULT_VALIDATE_PEGIN));
     strUsage += HelpMessageOpt("-mainchainrpchost=<addr>", strprintf("The address which the daemon will try to connect to validate peg-ins, if enabled. (default: cookie auth)"));
@@ -1053,6 +1054,9 @@ bool AppInitParameterInteraction()
     }
     if (GetArg("-permissioncoinsdestination", "").size() > 0) {
         permissionAsset = CAsset(uint256S(chainparams.GetConsensus().permission_asset.GetHex()));
+    }
+    if (GetArg("-issuancecoinsdestination", "").size() > 0) {
+        issuanceAsset = CAsset(uint256S(chainparams.GetConsensus().issuance_asset.GetHex()));
     }
     // Fee-per-kilobyte amount considered the same as "free"
     // If you are mining, be careful setting this:

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -18,6 +18,7 @@ CAsset burnlistAsset;
 CAsset whitelistAsset;
 CAsset challengeAsset;
 CAsset permissionAsset;
+CAsset issuanceAsset;
 
 /**
      * Check transaction inputs to mitigate two
@@ -167,12 +168,12 @@ bool IsWhitelistAsset(CAsset const &asset){
 }
 
 bool IsPolicy(const CAsset& asset){
-    if (asset == policyAsset ||
-        asset == freezelistAsset ||
+    if (asset == freezelistAsset ||
         asset == burnlistAsset ||
         asset == whitelistAsset ||
         asset == challengeAsset ||
-        asset == permissionAsset)
+        asset == permissionAsset ||
+        asset == issuanceAsset)
         return true;
     return false;
 }

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -167,6 +167,10 @@ bool IsWhitelistAsset(CAsset const &asset){
   return (asset == whitelistAsset);
 }
 
+bool IsPermissionAsset(CAsset const &asset){
+  return (asset == permissionAsset);
+}
+
 bool IsPolicy(const CAsset& asset){
     if (asset == freezelistAsset ||
         asset == burnlistAsset ||

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -121,6 +121,11 @@ bool IsWhitelistAssetOnly(CTransaction const &tx);
 bool IsWhitelistAsset(CAsset const &asset);
 
 /**
+ * Check if an asset is of permission type
+ */
+bool IsPermissionAsset(CAsset const &asset);
+
+/**
  * Check if a transaction has outputs what are of a policy asset type
  */
 bool IsPolicy(const CTransaction& tx);

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -31,6 +31,8 @@ extern CAsset whitelistAsset;
 extern CAsset challengeAsset;
 /** the asset for request permissions **/
 extern CAsset permissionAsset;
+/** the asset for issuance policy **/
+extern CAsset issuanceAsset;
 
 /** Default for -blockmaxsize, which controls the maximum size of block the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 1000000;

--- a/src/request.h
+++ b/src/request.h
@@ -11,6 +11,7 @@
 #include "pubkey.h"
 #include "amount.h"
 #include "script/script.h"
+#include <cmath>
 
 using namespace std;
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -49,6 +49,8 @@ static std::condition_variable cond_blockchange;
 static CUpdatedBlock latestblock;
 
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
+extern UniValue requestToJSON(const CRequest &request);
+extern UniValue bidToJSON(const CBid &bid);
 void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 
 double GetDifficulty(const CBlockIndex* blockindex)
@@ -1000,29 +1002,6 @@ UniValue gettxoutsetinfo(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to read UTXO set");
     }
     return ret;
-}
-
-UniValue requestToJSON(const CRequest &request)
-{
-    UniValue item(UniValue::VOBJ);
-    item.push_back(Pair("genesisBlock", request.hashGenesis.GetHex()));
-    item.push_back(Pair("confirmedBlockHeight", (int32_t)request.nConfirmedBlockHeight));
-    item.push_back(Pair("startBlockHeight", (int32_t)request.nStartBlockHeight));
-    item.push_back(Pair("numTickets", (int32_t)request.nNumTickets));
-    item.push_back(Pair("decayConst", (int32_t)request.nDecayConst));
-    item.push_back(Pair("feePercentage", (int32_t)request.nFeePercentage));
-    item.push_back(Pair("endBlockHeight", (int32_t)request.nEndBlockHeight));
-    item.push_back(Pair("startPrice", ValueFromAmount(request.nStartPrice)));
-    item.push_back(Pair("auctionPrice", ValueFromAmount(request.GetAuctionPrice(chainActive.Height()))));
-    return item;
-}
-
-UniValue bidToJSON(const CBid &bid)
-{
-    UniValue item(UniValue::VOBJ);
-    item.push_back(Pair("txid", bid.hashBid.ToString()));
-    item.push_back(Pair("feePubKey", HexStr(bid.feePubKey)));
-    return item;
 }
 
 UniValue getrequestbids(const JSONRPCRequest& request)

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -254,6 +254,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
                     }
                     else if (solverRes && whichType == TX_LOCKED_MULTISIG && isPolicy == false) {
                         CBid bid = CBid::FromSolutions(vSolutions, txout.nValue.GetAmount(), pindex->nHeight);
+                        bid.SetBidHash(tx.GetHash());
                         UniValue item(UniValue::VOBJ);
                         item.push_back(Pair("txid", bid.hashBid.ToString()));
                         item.push_back(Pair("feePubKey", HexStr(bid.feePubKey)));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -25,6 +25,8 @@
 #include "uint256.h"
 #include "utilstrencodings.h"
 #include "util.h"
+#include "global/common.h"
+#include "assetsdir.h"
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
 #endif
@@ -167,6 +169,11 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
             } else if (issuance.nInflationKeys.IsCommitment()) {
                 issue.push_back(Pair("tokenamountcommitment", HexStr(issuance.nInflationKeys.vchCommitment)));
             }
+            const std::string policyLabel = gAssetsDir.GetLabel(asset);
+            if (policyLabel != "") 
+            {
+                issue.push_back(Pair("assetlabel", policyLabel));
+            }
             in.push_back(Pair("issuance", issue));
         }
         in.push_back(Pair("sequence", (int64_t)txin.nSequence));
@@ -202,6 +209,11 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
             out.push_back(Pair("asset", asset.GetAsset().GetHex()));
         } else if (asset.IsCommitment()) {
             out.push_back(Pair("assetcommitment", HexStr(asset.vchCommitment)));
+        }
+        const std::string policyLabel = gAssetsDir.GetLabel(asset.GetAsset());
+        if (policyLabel != "") 
+        {
+            out.push_back(Pair("assetlabel", policyLabel));
         }
         out.push_back(Pair("n", (int64_t)i));
         UniValue o(UniValue::VOBJ);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -210,10 +210,12 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
         } else if (asset.IsCommitment()) {
             out.push_back(Pair("assetcommitment", HexStr(asset.vchCommitment)));
         }
-        const std::string policyLabel = gAssetsDir.GetLabel(asset.GetAsset());
-        if (policyLabel != "") 
-        {
-            out.push_back(Pair("assetlabel", policyLabel));
+        if (asset.IsExplicit()) {
+            std::string policyLabel = gAssetsDir.GetLabel(asset.GetAsset());
+            if (policyLabel != "") 
+            {
+                out.push_back(Pair("assetlabel", policyLabel));
+            }
         }
         out.push_back(Pair("n", (int64_t)i));
         UniValue o(UniValue::VOBJ);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -107,6 +107,15 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     entry.push_back(Pair("vsize", (int)::GetVirtualTransactionSize(tx)));
     entry.push_back(Pair("version", tx.nVersion));
     entry.push_back(Pair("locktime", (int64_t)tx.nLockTime));
+
+    CBlockIndex* pindex = NULL;
+    if (!hashBlock.IsNull()) {
+        BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
+        if (mi != mapBlockIndex.end() && (*mi).second) {
+            pindex = (*mi).second;
+        }
+    }
+
     UniValue vin(UniValue::VARR);
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
         const CTxIn& txin = tx.vin[i];
@@ -221,21 +230,53 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
         UniValue o(UniValue::VOBJ);
         ScriptPubKeyToJSON(txout.scriptPubKey, o, true);
         out.push_back(Pair("scriptPubKey", o));
+
+        if (asset.IsExplicit()) {
+            if (pindex != NULL) {
+                if (chainActive.Contains(pindex)) {
+                    vector<vector<unsigned char>> vSolutions;
+                    txnouttype whichType;
+                    bool solverRes = Solver(txout.scriptPubKey, whichType, vSolutions);
+                    bool isPolicy = IsPolicy(asset.GetAsset());
+                    if (solverRes && whichType == TX_LOCKED_MULTISIG && isPolicy == true) {
+                        CRequest request = CRequest::FromSolutions(vSolutions, pindex->nHeight);
+                        UniValue item(UniValue::VOBJ);
+                        item.push_back(Pair("genesisBlock", request.hashGenesis.GetHex()));
+                        item.push_back(Pair("confirmedBlockHeight", (int32_t)request.nConfirmedBlockHeight));
+                        item.push_back(Pair("startBlockHeight", (int32_t)request.nStartBlockHeight));
+                        item.push_back(Pair("numTickets", (int32_t)request.nNumTickets));
+                        item.push_back(Pair("decayConst", (int32_t)request.nDecayConst));
+                        item.push_back(Pair("feePercentage", (int32_t)request.nFeePercentage));
+                        item.push_back(Pair("endBlockHeight", (int32_t)request.nEndBlockHeight));
+                        item.push_back(Pair("startPrice", ValueFromAmount(request.nStartPrice)));
+                        item.push_back(Pair("auctionPrice", ValueFromAmount(request.GetAuctionPrice(chainActive.Height()))));
+                        out.push_back(Pair("request", item));
+                    }
+                    else if (solverRes && whichType == TX_LOCKED_MULTISIG && isPolicy == false) {
+                        CBid bid = CBid::FromSolutions(vSolutions, txout.nValue.GetAmount(), pindex->nHeight);
+                        UniValue item(UniValue::VOBJ);
+                        item.push_back(Pair("txid", bid.hashBid.ToString()));
+                        item.push_back(Pair("feePubKey", HexStr(bid.feePubKey)));
+                        out.push_back(Pair("bid", item));
+                    }
+                }
+            }
+        }
+
         vout.push_back(out);
     }
     entry.push_back(Pair("vout", vout));
     if (!hashBlock.IsNull()) {
         entry.push_back(Pair("blockhash", hashBlock.GetHex()));
-        BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
-        if (mi != mapBlockIndex.end() && (*mi).second) {
-            CBlockIndex* pindex = (*mi).second;
+        if (pindex != NULL) {
             if (chainActive.Contains(pindex)) {
                 entry.push_back(Pair("confirmations", 1 + chainActive.Height() - pindex->nHeight));
                 entry.push_back(Pair("time", pindex->GetBlockTime()));
                 entry.push_back(Pair("blocktime", pindex->GetBlockTime()));
             }
-            else
+            else {
                 entry.push_back(Pair("confirmations", 0));
+            }
         }
     }
 }

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -53,6 +53,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::st
         }
         // MAX_MONEY
         SoftSetArg("-initialfreecoins", "2100000000000000");
+        SoftSetArg("-policycoins", "2100000000000000");
         SelectParams(chainName);
         noui_connect();
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1193,11 +1193,11 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool, CValidationState &state,
     if(fEnableBurnlistCheck && !IsPolicy(tx) && IsAnyBurn(tx) && !test_accept)
         if(!IsBurnlisted(tx, view))
             return state.DoS(0, false, REJECT_NONSTANDARD, "burn-tx-not-burnlisted");
-    // Accept only transactions that are asset issuances if they have a policyAsset input.
+    // Accept only transactions that are asset issuances if they have a issuanceAsset input.
     if (fblockissuancetx) {
       CAssetIssuance const &issuance = tx.vin[0].assetIssuance;
       if (!issuance.IsNull() && !issuance.IsReissuance()) {
-        CAsset pAsset(policyAsset);
+        CAsset pAsset(issuanceAsset);
         CTxOut const &prev = view.GetOutputFor(tx.vin[0]);
         CAsset asset;
         asset = prev.nAsset.GetAsset();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4168,7 +4168,7 @@ UniValue createrawissuance(const JSONRPCRequest& request)
   CalculateReissuanceToken(token, entropy, fBlindIssuances);
 
   //generate the outputs
-  CAsset pAsset(policyAsset);
+  CAsset pAsset(issuanceAsset);
   CTxOut txoutAsset(asset,nAmount,GetScriptForDestination(assetAddr.Get()));
   rawTx.vout.push_back(txoutAsset);
   CTxOut txoutToken(token,nTokens,GetScriptForDestination(tokenAddr.Get()));


### PR DESCRIPTION
I have made significant changes to the getrawtransaction rpc. A new assetlabel field has been added for all policy assets (WHITELIST, BURNLIST, etc). Additionally, an extra field ("request" or "bid") has been added to outputs of lockedmultisig type. These fields parse and store data for transactions that carry information relating to the auction. I have implemented issuanceAsset which has replaced policyAsset in some locations. Changes have been made to QA tests to accommodate these features.

Fixes #117 