### PR TITLE
Fix for issue number 59. Block validated before policy lists updated.

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -584,6 +584,11 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins,
                   const CChainParams& chainparams, std::set<std::pair<uint256, COutPoint> >* setPeginsSpent = NULL, bool fJustCheck = false);
 
+
+/** Apply the effects of this block to the policy lists.
+*/
+void UpdatePolicyLists(const CBlock& block, const CCoinsViewCache& view);
+
 /** Undo the effects of this block (with given index) on the UTXO set represented by coins.
  *  In case pfClean is provided, operation will try to be tolerant about errors, and *pfClean
  *  will be true if no problems were found. Otherwise, the return value will be false in case


### PR DESCRIPTION
This fixes issue number 59. 
However, if these changes are approved, the policy lists, asset map and freeze history will be updated after all other transactions will have been processed. Therefore, the policy updates will not come into effect until the next block.