### PR TITLE
Minor change to safety checks for comparing multisig tweaked id's

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1858,7 +1858,7 @@ bool CheckValidTweakedAddress(const CTxDestination keyID, const std::vector<CPub
     if (multiKeyId.which() == ((CTxDestination)CNoDestination()).which())
         return false;
 
-    if (!(multiKeyId == destCopy))
+    if (!(boost::get<CScriptID>(multiKeyId) == boost::get<CScriptID>(destCopy)))
         return false;
 
     return true;


### PR DESCRIPTION
Title describes all. Comparing two CTxDestinations could result in weirdness as the variant types each have different behaviour for overloaded comparison operator.