### PR TITLE
Fixed an issue with multisig whitelisting

### DIFF
--- a/qa/rpc-tests/onboardmanual.py
+++ b/qa/rpc-tests/onboardmanual.py
@@ -111,9 +111,12 @@ class OnboardManualTest (BitcoinTestFramework):
         onboardAddress1=self.nodes[1].validateaddress(self.nodes[1].getnewaddress())
         onboardAddress2=self.nodes[1].validateaddress(self.nodes[1].getnewaddress())
         onboardAddress3=self.nodes[1].validateaddress(self.nodes[1].getnewaddress())
+        onboardAddress4=self.nodes[1].validateaddress(self.nodes[1].getnewaddress())
         untweakedPubkeys=[onboardAddress1['derivedpubkey'],onboardAddress2['derivedpubkey'],onboardAddress3['derivedpubkey']]
+        untweakedPubkeys2=[onboardAddress2['derivedpubkey'],onboardAddress3['derivedpubkey'],onboardAddress4['derivedpubkey']]
+        untweakedPubkeys3=[onboardAddress3['derivedpubkey'],onboardAddress4['derivedpubkey']]
         try:
-            userOnboardPubKey=self.nodes[1].createkycfile(kycfile, [{"address":onboardAddress1['address'],"pubkey":onboardAddress1['derivedpubkey']},{"address":onboardAddress2['address'],"pubkey":onboardAddress2['derivedpubkey']}], [{"nmultisig":2,"pubkeys":untweakedPubkeys}]);
+            userOnboardPubKey=self.nodes[1].createkycfile(kycfile, [{"address":onboardAddress1['address'],"pubkey":onboardAddress1['derivedpubkey']},{"address":onboardAddress2['address'],"pubkey":onboardAddress2['derivedpubkey']}], [{"nmultisig":2,"pubkeys":untweakedPubkeys},{"nmultisig":2,"pubkeys":untweakedPubkeys2},{"nmultisig":2,"pubkeys":untweakedPubkeys3}]);
         except JSONRPCException as e:
             print(e.error['message'])
             assert(False)
@@ -155,6 +158,22 @@ class OnboardManualTest (BitcoinTestFramework):
         assert(iswl)
 
         multiAdr=self.nodes[1].createmultisig(2,[onboardAddress1['pubkey'],onboardAddress2['pubkey'],onboardAddress3['pubkey']])
+        try:
+            iswl2=self.nodes[0].querywhitelist(multiAdr['address'])
+        except JSONRPCException as e:
+            print(e.error['message'])
+            assert(False)
+        assert(iswl2)
+
+        multiAdr=self.nodes[1].createmultisig(2,[onboardAddress2['pubkey'],onboardAddress3['pubkey'],onboardAddress4['pubkey']])
+        try:
+            iswl2=self.nodes[0].querywhitelist(multiAdr['address'])
+        except JSONRPCException as e:
+            print(e.error['message'])
+            assert(False)
+        assert(iswl2)
+
+        multiAdr=self.nodes[1].createmultisig(2,[onboardAddress3['pubkey'],onboardAddress4['pubkey']])
         try:
             iswl2=self.nodes[0].querywhitelist(multiAdr['address'])
         except JSONRPCException as e:

--- a/src/policy/kycfile.cpp
+++ b/src/policy/kycfile.cpp
@@ -162,6 +162,7 @@ bool CKYCFile::read(){
 void CKYCFile::parsePubkeyPair(const std::vector<std::string> vstr, const std::string line){
     CBitcoinAddress address;
     if (!address.SetString(vstr[0])) {
+        _decryptedStream << line << ": invalid base58check address: "  << vstr[0] << "\n";
         return;
     }
 
@@ -206,6 +207,7 @@ void CKYCFile::parseMultisig(const std::vector<std::string> vstr, const std::str
     
     CBitcoinAddress address;
     if (!address.SetString(vstr[1])) {
+        _decryptedStream << line << ": invalid base58check address: "  << vstr[0] << "\n";
         return;
     }
 

--- a/src/policy/kycfile.cpp
+++ b/src/policy/kycfile.cpp
@@ -207,7 +207,7 @@ void CKYCFile::parseMultisig(const std::vector<std::string> vstr, const std::str
     
     CBitcoinAddress address;
     if (!address.SetString(vstr[1])) {
-        _decryptedStream << line << ": invalid base58check address: "  << vstr[0] << "\n";
+        _decryptedStream << line << ": invalid base58check address: "  << vstr[1] << "\n";
         return;
     }
 

--- a/src/policy/whitelist.cpp
+++ b/src/policy/whitelist.cpp
@@ -14,6 +14,8 @@
 
 CWhiteList::CWhiteList(){
   _asset=whitelistAsset;
+  //The written code behaviour expects nMultisigSize to be of length 1 at the moment. If it is changed in the future the code needs to be adjusted accordingly.
+  assert(nMultisigSize == 1);
 }
 CWhiteList::~CWhiteList(){;}
 

--- a/src/policy/whitelist.cpp
+++ b/src/policy/whitelist.cpp
@@ -469,11 +469,6 @@ bool CWhiteList::RegisterDecryptedAddresses(const std::vector<unsigned char>& da
     //REGISTERADDRESS for MULTISIG
     else{
 
-      if(nMultisigSize != 1){
-        LogPrintf("Undefined behaviour, the nMultisigSize was set to a number other than 1. Changes may be necessary to accommodate the extra bytes.\n");
-        return bSuccess;
-      }
-
       itData2 += nMultisigSize;
 
       uint8_t mMultisig = 0;

--- a/src/policy/whitelist.cpp
+++ b/src/policy/whitelist.cpp
@@ -468,17 +468,27 @@ bool CWhiteList::RegisterDecryptedAddresses(const std::vector<unsigned char>& da
     }
     //REGISTERADDRESS for MULTISIG
     else{
-      itData2 += nMultisigSize;
-
-      uint8_t nMultisig = 0;
-      std::vector<unsigned char> nMultisigChars(itData1,itData2);
 
       if(nMultisigSize != 1){
         LogPrintf("Undefined behaviour, the nMultisigSize was set to a number other than 1. Changes may be necessary to accommodate the extra bytes.\n");
         return bSuccess;
       }
 
-      nMultisig = (uint8_t)nMultisigChars[0];
+      itData2 += nMultisigSize;
+
+      uint8_t mMultisig = 0;
+      std::vector<unsigned char> mMultisigChars(itData1,itData2);
+
+      mMultisig = mMultisigChars[0];
+
+      itData1 = itData2;
+
+      itData2 += nMultisigSize;
+
+      uint8_t nMultisig = 0;
+      std::vector<unsigned char> nMultisigChars(itData1,itData2);
+
+      nMultisig = nMultisigChars[0];
 
       itData1 = itData2;
 
@@ -491,18 +501,21 @@ bool CWhiteList::RegisterDecryptedAddresses(const std::vector<unsigned char>& da
       std::vector<CPubKey> vPubKeys;
 
       itData1=itData2;
-      bool fEnd = false;
 
-      while(!fEnd){
+      unsigned int pubkeyNr = static_cast<unsigned int>(nMultisig);
+
+      for (unsigned int j=0; j < pubkeyNr; ++j){
+
+        if(bEnd == true)
+          break;
+
         for(unsigned int i=0; i<CPubKey::COMPRESSED_PUBLIC_KEY_SIZE; ++i){
           if(itData2++ == pend){
             bEnd = true;
-            fEnd = true;
             break;
           }
         }
-
-        if(!fEnd){
+        if(!bEnd){
           CPubKey pubKeyNew = CPubKey(itData1,itData2);
           if(!pubKeyNew.IsFullyValid()){
             itData2=itData1;
@@ -514,7 +527,7 @@ bool CWhiteList::RegisterDecryptedAddresses(const std::vector<unsigned char>& da
       }
 
       try{
-        add_multisig_whitelist(addrMultiNew, vPubKeys, kycPubKey, nMultisig);
+        add_multisig_whitelist(addrMultiNew, vPubKeys, kycPubKey, mMultisig);
       } catch (std::invalid_argument e){
         LogPrintf(std::string(e.what()) + "\n");
         return bSuccess;
@@ -538,7 +551,20 @@ bool CWhiteList::IsRegisterAddressMulti(const std::vector<unsigned char>::const_
     }
   }
 
-  uint8_t nMultisig = (uint8_t)*start;
+  uint8_t mMultisig = *start;
+
+  if(mMultisig > MAX_P2SH_SIGOPS || mMultisig == 0)
+    return false;
+
+  point1 = point2;
+
+  for(unsigned int i=0; i<nMultisigSize; ++i){
+    if(point2++ == vend) {
+      return false;
+    }
+  }
+
+  uint8_t nMultisig = *point1;
 
   if(nMultisig > MAX_P2SH_SIGOPS || nMultisig == 0)
     return false;

--- a/src/policy/whitelist.h
+++ b/src/policy/whitelist.h
@@ -149,6 +149,7 @@ private:
 	void synchronise(CWhiteList* wl_new);
 
   	const unsigned int addrSize=20;
+  	//The written code behaviour expects nMultisigSize to be of length 1 at the moment. If it is changed in the future the code needs to be adjusted accordingly.
   	const unsigned int nMultisigSize=1;
   	const unsigned int minPayloadSize=2;
 

--- a/src/script/registeraddressscript.cpp
+++ b/src/script/registeraddressscript.cpp
@@ -90,6 +90,9 @@ bool CRegisterAddressScript::Append(const uint8_t nMultisig, const CTxDestinatio
     _payload.insert(_payload.end(), 
                     (unsigned char)nMultisig);
 
+    _payload.insert(_payload.end(), 
+                    (unsigned char)keys.size());
+
     CScriptID scriptID = boost::get<CScriptID>(keyID);
     _payload.insert(_payload.end(), 
                     scriptID.begin(), 


### PR DESCRIPTION
The transaction now includes the number of pub keys that each Multisig has.
A couple of extra python tests for it were added.