### PR TITLE
Fixed dpkg control file versioning

### DIFF
--- a/contrib/docker/dpkg-build/Dockerfile
+++ b/contrib/docker/dpkg-build/Dockerfile
@@ -23,7 +23,7 @@ RUN set -ex \
     && mkdir -p ocean-$(git rev-parse --short HEAD)/DEBIAN \
     && cp contrib/docker/dpkg-build/control \
         ocean-$(git rev-parse --short HEAD)/DEBIAN/ \
-    && sed -i "s/Version:*/Version: $(git rev-parse --short HEAD)/" \
+    && sed -i "s/Version:*/Version: 1.0-$(git rev-parse --short HEAD)/" \
         ocean-$(git rev-parse --short HEAD)/DEBIAN/control \
     && dpkg-deb --build ocean-$(git rev-parse --short HEAD) \
     && go run github-release/main.go "Debian package" \


### PR DESCRIPTION
    dpkg requires package versions to start with a number
    "dpkg-deb: error: parsing file 'ocean-a80b99655/DEBIAN/control' near line 2 package 'ocean':
     error in 'Version' field string 'a80b99655': version number does not start with digit"
    This fix prepends 1.0- to the git commit short hash which is used as a versison number.