### PR TITLE
HARD FORK: changed coinbase maturity to 2 blocks

### DIFF
--- a/qa/rpc-tests/replace-by-fee.py
+++ b/qa/rpc-tests/replace-by-fee.py
@@ -311,8 +311,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
     def test_spends_of_conflicting_outputs(self):
         """Replacements that spend conflicting tx outputs are rejected"""
-        utxo1 = make_utxo(self.nodes[0], int(1.2*COIN))
-        utxo2 = make_utxo(self.nodes[0], 3*COIN)
+        utxo1 = make_utxo(self.nodes[0], int(1.2*COIN), False)
+        utxo2 = make_utxo(self.nodes[0], 3*COIN, False)
 
         tx1a = CTransaction()
         tx1a.vin = [CTxIn(utxo1, nSequence=0)]

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -17,7 +17,7 @@ static const unsigned int MAX_BLOCK_BASE_SIZE = 1000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
-static const int COINBASE_MATURITY = 100;
+static const int COINBASE_MATURITY = 2;
 
 /** Flags for nSequence and nLockTime locks */
 enum {


### PR DESCRIPTION
Coinbase txs can be spent after 2 confirmations - this is required to enable the redemption of the final asset in the inflation model. 