### PR TITLE
Signcontract

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -163,6 +163,7 @@ testScripts = [
     #'p2p-segwit.py',
     #'importprunedfunds.py',
     'signmessages.py',
+    'signcontract.py',
     #'nulldummy.py',
     # TODO reactivate this
     #'import-rescan.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -113,6 +113,7 @@ testScripts = [
     'whitelisting.py',
     'policytransactions.py',
     'onboard.py',
+    'onboard_cit.py',
     'onboardmanual.py',
     # Accounts not supported
     #'wallet-accounts.py',
@@ -163,7 +164,7 @@ testScripts = [
     #'p2p-segwit.py',
     #'importprunedfunds.py',
     'signmessages.py',
-    'signcontract.py',
+    'contractintx.py',
     #'nulldummy.py',
     # TODO reactivate this
     #'import-rescan.py',

--- a/qa/rpc-tests/contractintx.py
+++ b/qa/rpc-tests/contractintx.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import filecmp
+import time
+
+class ContractInTxTest (BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+        self.extra_args = [['-txindex'] for i in range(3)]
+        self.extra_args[0].append("-regtest=0")
+        self.extra_args[0].append("-contractintx=1")
+        self.extra_args[1].append("-regtest=0")
+        self.extra_args[1].append("-contractintx=1")
+        self.extra_args[2].append("-regtest=0")
+        self.extra_args[2].append("-contractintx=0")
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(3, self.options.tmpdir, self.extra_args[:3])
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,0,2)
+        self.is_network_split=False
+        self.sync_all()
+
+    def run_test (self):
+    
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        genhash = self.nodes[0].getblockhash(0)
+        genblock = self.nodes[0].getblock(genhash)
+
+        #send coins from node 0 to node 1
+        addr1 = self.nodes[1].getnewaddress()
+        txid1 = self.nodes[0].sendtoaddress(addr1,100.0)
+
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        rawtx1 = self.nodes[0].getrawtransaction(txid1,True)
+        assert(rawtx1['confirmations'] == 101)
+
+        #send some coins from node 0 to node 2
+        addr2 = self.nodes[2].getnewaddress()
+        txid2 = self.nodes[0].sendtoaddress(addr2,100.0)
+
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        #send some coins back from node 2 to node 0
+        addr3 = self.nodes[0].getnewaddress()
+        txid3 = self.nodes[2].sendtoaddress(addr3,50.0)
+
+        #check txid3 is in the mempool of node 2
+        memp1 = self.nodes[2].getrawmempool()
+
+        assert(txid3 in memp1)
+
+        #check txid3 is not in the mempool of node 0 (blocked)
+        memp2 = self.nodes[0].getrawmempool()
+
+        assert(not txid3 in memp2)
+
+if __name__ == '__main__':
+ ContractInTxTest().main()

--- a/qa/rpc-tests/onboard_cit.py
+++ b/qa/rpc-tests/onboard_cit.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import filecmp
+import time
+
+class OnboardTest (BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+        self.extra_args = [['-txindex'] for i in range(3)]
+        self.extra_args[0].append("-keypool=100")
+        self.extra_args[0].append("-freezelist=1")
+        self.extra_args[0].append("-burnlist=1")
+        self.extra_args[0].append("-pkhwhitelist=1")
+        self.extra_args[0].append("-rescan=1")
+        self.extra_args[0].append("-initialfreecoins=2100000000000000")
+        self.extra_args[0].append("-policycoins=50000000000000")
+        self.extra_args[0].append("-regtest=0")
+        self.extra_args[0].append("-contractintx=1")
+        self.extra_args[0].append("-initialfreecoinsdestination=76a914b87ed64e2613422571747f5d968fff29a466e24e88ac")
+        self.extra_args[0].append("-issuancecoinsdestination=76a914df4439eb1a54b3a91d71979a0bb5b3f5971ff44c88ac")
+        self.extra_args[0].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
+        self.extra_args[0].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
+        self.extra_args[0].append("-whitelistcoinsdestination=76a914427bf8530a3962ed77fd3c07d17fd466cb31c2fd88ac")
+        self.extra_args[1].append("-rescan=1")
+        self.extra_args[1].append("-regtest=0")
+        self.extra_args[1].append("-contractintx=1")
+        self.extra_args[1].append("-pkhwhitelist-scan=1")
+        self.extra_args[1].append("-keypool=100")
+        self.extra_args[1].append("-freezelist=1")
+        self.extra_args[1].append("-burnlistist=1")
+        self.extra_args[1].append("-initialfreecoins=2100000000000000")
+        self.extra_args[1].append("-policycoins=50000000000000")
+        self.extra_args[1].append("-initialfreecoinsdestination=76a914b87ed64e2613422571747f5d968fff29a466e24e88ac")
+        self.extra_args[1].append("-issuancecoinsdestination=76a914df4439eb1a54b3a91d71979a0bb5b3f5971ff44c88ac")
+        self.extra_args[1].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
+        self.extra_args[1].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
+        self.extra_args[1].append("-whitelistcoinsdestination=76a914427bf8530a3962ed77fd3c07d17fd466cb31c2fd88ac")
+        self.extra_args[2].append("-keypool=100")
+        self.extra_args[2].append("-freezelist=1")
+        self.extra_args[2].append("-burnlist=1")
+        self.extra_args[2].append("-pkhwhitelist=1")
+        self.extra_args[2].append("-rescan=1")
+        self.extra_args[2].append("-initialfreecoins=2100000000000000")
+        self.extra_args[2].append("-policycoins=50000000000000")
+        self.extra_args[2].append("-regtest=0")
+        self.extra_args[2].append("-contractintx=1")
+        self.extra_args[2].append("-initialfreecoinsdestination=76a914b87ed64e2613422571747f5d968fff29a466e24e88ac")
+        self.extra_args[2].append("-issuancecoinsdestination=76a914df4439eb1a54b3a91d71979a0bb5b3f5971ff44c88ac")
+        self.extra_args[2].append("-freezelistcoinsdestination=76a91474168445da07d331faabd943422653dbe19321cd88ac")
+        self.extra_args[2].append("-burnlistcoinsdestination=76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac")
+        self.extra_args[2].append("-whitelistcoinsdestination=76a914427bf8530a3962ed77fd3c07d17fd466cb31c2fd88ac")
+        self.files=[]
+        self.nodes=[]
+
+    def setup_network(self, split=False):
+        #Start a node, get the wallet file, stop the node and use the wallet file as the whitelisting wallet
+        #Start nodes
+        self.nodes = start_nodes(3, self.options.tmpdir, self.extra_args[:3])
+        #Set up wallet path and dump the wallet
+        wlwalletname="wlwallet.dat"
+        wlwalletpath=os.path.join(self.options.tmpdir,wlwalletname)
+        time.sleep(5)
+        self.nodes[0].backupwallet(wlwalletpath)
+        
+        #Stop the nodes
+        stop_nodes(self.nodes)
+        time.sleep(5)
+
+        #Copy the wallet file to the node 0 and 2 data dirs
+        #Give nodes 0 and 2 the same wallet (whitelist wallet)
+        node0path=os.path.join(self.options.tmpdir, "node"+str(0))
+        node1path=os.path.join(self.options.tmpdir, "node"+str(1))
+        node2path=os.path.join(self.options.tmpdir, "node"+str(2))
+
+        dest0=os.path.join(node0path, "ocean_test")
+        dest0=os.path.join(dest0, wlwalletname)
+        dest2=os.path.join(node2path, "ocean_test")
+        dest2=os.path.join(dest2, wlwalletname)
+
+        shutil.copyfile(wlwalletpath,dest0)
+        shutil.copyfile(wlwalletpath,dest2)
+        
+        time.sleep(5)
+
+        #Start the nodes again with a different wallet path argument
+        self.extra_args[0].append("-wallet="+wlwalletname)
+        self.extra_args[2].append("-wallet="+wlwalletname)
+        self.nodes = start_nodes(3, self.options.tmpdir, self.extra_args[:3])
+
+        time.sleep(5)
+
+        #Node0 and node2 wallets should be the same
+        addr0=self.nodes[0].getnewaddress()
+        addr2=self.nodes[2].getnewaddress()
+
+        assert(addr0 == addr2)
+
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,0,2)
+        self.is_network_split=False
+        self.sync_all()
+
+    def linecount(self, file):
+        nlines=0
+        with open(file) as f:
+            for nlines, l in enumerate(f):
+                pass
+        return nlines
+
+    def initfile(self, filename):
+        self.files.append(filename)
+        self.removefileifexists(filename)
+        return filename
+
+    def removefileifexists(self, filename):
+        if(os.path.isfile(filename)):
+            os.remove(filename)
+
+    def cleanup_files(self):
+        for file in self.files:
+            self.removefileifexists(file)
+
+    def run_test (self):
+        keypool=1
+
+        # import the policy keys into node 0
+        self.nodes[0].importprivkey("cS29UJMQrpnee7UaUHo6NqJVpGr35TEqUDkKXStTnxSZCGUWavgE")
+        self.nodes[0].importprivkey("cND4nfH6g2SopoLk5isQ8qGqqZ5LmbK6YwJ1QnyoyMVBTs8bVNNd")
+        self.nodes[0].importprivkey("cTnxkovLhGbp7VRhMhGThYt8WDwviXgaVAD8DjaVa5G5DApwC6tF")
+        self.nodes[0].importprivkey("cNCQhCnpnzyeYh48NszsTJC2G4HPoFMZguUnUgBpJ5X9Vf2KaPYx")
+        #Initial free coins
+        self.nodes[0].importprivkey("cQRC9YB11Li3QHqyxMPff3uznfRggMUYdixctbyNdWdnNWr3koZy")
+        #Issuance
+        self.nodes[0].importprivkey("cSdWz4JStWKgVMQrdQ8TCqzmhAt7jprCPxvrZMpzy4s6WcBuW9NW")
+
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        # issue some new asset (that is not the policy asset)
+        issue = self.nodes[0].issueasset('100.0','0', False)
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        #find txouts for the freezelistasset and burnlistasset
+        issuescript = "76a914b87ed64e2613422571747f5d968fff29a466e24e88ac"
+        pascript = "76a914b87ed64e2613422571747f5d968fff29a466e24e88ac"
+        flscript = "76a91474168445da07d331faabd943422653dbe19321cd88ac"
+        blscript = "76a9142166a4cd304b86db7dfbbc7309131fb0c4b645cd88ac"
+        wlscript = "76a914427bf8530a3962ed77fd3c07d17fd466cb31c2fd88ac"
+        genhash = self.nodes[0].getblockhash(0)
+        genblock = self.nodes[0].getblock(genhash)
+
+        for txid in genblock["tx"]:
+            rawtx = self.nodes[0].getrawtransaction(txid,True)
+            if rawtx["vout"][0]["scriptPubKey"]["hex"] == flscript:
+                flasset = rawtx["vout"][0]["asset"]
+                fltxid = txid
+                flvalue = rawtx["vout"][0]["value"]
+            if rawtx["vout"][0]["scriptPubKey"]["hex"] == blscript:
+                blasset = rawtx["vout"][0]["asset"]
+                bltxid = txid
+                blvalue = rawtx["vout"][0]["value"]
+            if rawtx["vout"][0]["scriptPubKey"]["hex"] == pascript:
+                paasset = rawtx["vout"][0]["asset"]
+                patxid = txid
+                pavalue = rawtx["vout"][0]["value"]
+            if "assetlabel" in rawtx["vout"][0]:
+                if rawtx["vout"][0]["assetlabel"] == "WHITELIST":
+                    wlasset = rawtx["vout"][0]["asset"]
+                    wltxid = txid
+                    wlvalue = rawtx["vout"][0]["value"]
+
+        #No kycpubkeys available
+        kycfile="kycfile.dat"
+        try:
+            userOnboardPubKey=self.nodes[1].dumpkycfile(kycfile)
+        except JSONRPCException as e:
+            assert("No unassigned KYC public keys available" in e.error['message'])
+
+        #Register a KYC public key
+        self.nodes[0].topupkycpubkeys(100)
+        self.nodes[0].generate(101)
+        self.sync_all()
+        time.sleep(5)
+
+
+        #Onboard node0
+        kycfile0=self.initfile("kycfile0.dat")
+        userOnboardPubKey=self.nodes[0].dumpkycfile(kycfile0)
+        self.nodes[0].onboarduser(kycfile0)
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        #Onboard node1
+        kycfile=self.initfile("kycfile.dat")
+        userOnboardPubKey=self.nodes[1].dumpkycfile(kycfile)
+
+        self.nodes[0].generate(101)
+        self.sync_all()
+        time.sleep(5)
+
+        balance_1=self.nodes[0].getwalletinfo()["balance"]["WHITELIST"]
+        time.sleep(1)
+        self.nodes[0].onboarduser(kycfile)
+
+        self.nodes[0].generate(101)
+        self.sync_all()
+        balance_2=self.nodes[0].getwalletinfo()["balance"]["WHITELIST"]
+        #Make sure the onboard transaction fee was zero
+        assert((balance_1-balance_2) == 0)
+
+        node1addr=self.nodes[1].getnewaddress()
+
+        try:
+            iswl=self.nodes[0].querywhitelist(node1addr)
+        except JSONRPCException as e:
+            print(e.error['message'])
+            assert(False)
+        assert(iswl)
+
+
+        keypool=100
+        nwhitelisted=keypool
+
+        #Send some tokens to node 1
+        ntosend=10.234
+        self.nodes[0].sendtoaddress(node1addr, ntosend, "", "", False, "CBT")
+
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        bal1=self.nodes[1].getwalletinfo()["balance"]["CBT"]
+
+
+        assert_equal(float(bal1),float(ntosend))
+
+        #Restart the nodes. The whitelist will be restored. TODO
+        wl1file=self.initfile("wl1.dat")
+        self.nodes[1].dumpwhitelist(wl1file)
+
+        # time.sleep(1)
+        # try:
+        #     stop_node(self.nodes[1],1)
+        #  except ConnectionResetError as e:
+        #     pass
+        # except ConnectionRefusedError as e:
+        #     pass
+        # self.nodes[1] = start_node(1, self.options.tmpdir, self.extra_args[:3])
+        # wl1file_2="wl1_2.dat"
+        # self.nodes[1].dumpwhitelist(wl1file_2)
+        # assert(filecmp.cmp(wlfile, wlfile_2))
+
+        #Node 1 registers additional addresses to whitelist
+        nadd=100
+        saveres=self.nodes[1].sendaddtowhitelisttx(nadd,"CBT")
+        time.sleep(5)
+        self.nodes[0].generate(101)
+        self.sync_all()
+        nwhitelisted+=nadd
+        wl1file_2=self.initfile("wl1_2.dat")
+        self.nodes[1].dumpwhitelist(wl1file_2)
+        nlines1=self.linecount(wl1file)
+        nlines2=self.linecount(wl1file_2)
+        assert_equal(nlines2-nlines1, nadd)
+
+
+
+        self.nodes[1].sendaddtowhitelisttx(nadd,"CBT")
+        self.nodes[1].sendaddtowhitelisttx(nadd,"CBT")
+        self.nodes[1].sendaddtowhitelisttx(nadd,"CBT")
+        time.sleep(5)
+        self.nodes[0].generate(101)
+        self.sync_all()
+        nwhitelisted+=(3*nadd)
+        wl1file_3=self.initfile("wl1_3.dat")
+        self.nodes[1].dumpwhitelist(wl1file_3)
+        nlines3=self.linecount(wl1file_3)
+        assert_equal(nlines3-nlines2, 3*nadd)
+
+        clientAddress1=self.nodes[1].validateaddress(self.nodes[1].getnewaddress())
+        clientAddress2=self.nodes[1].validateaddress(self.nodes[1].getnewaddress())
+        clientAddress3=self.nodes[1].validateaddress(self.nodes[1].getnewaddress())
+        clientAddress4=self.nodes[1].validateaddress(self.nodes[1].getnewaddress())
+
+        #Creating a p2sh address for whitelisting
+        multiAddress2=self.nodes[1].createmultisig(2,[clientAddress2['pubkey'],clientAddress3['pubkey'],clientAddress4['pubkey']])
+
+        #Testing Multisig whitelisting registeraddress transaction
+        multitx = self.nodes[1].sendaddmultitowhitelisttx(multiAddress2['address'],[clientAddress2['derivedpubkey'],clientAddress3['derivedpubkey'],clientAddress4['derivedpubkey']],2,"CBT")
+
+        time.sleep(5)
+        self.nodes[0].generate(101)
+        self.sync_all()
+        nwhitelisted+=1
+        time.sleep(1)
+        wl1file_4=self.initfile("wl1_4.dat")
+        self.nodes[1].dumpwhitelist(wl1file_4)
+        nlines4=self.linecount(wl1file_4)
+        assert_equal(nlines3+1, nlines4)
+
+        try:
+            iswl=self.nodes[1].querywhitelist(multiAddress2['address'])
+        except JSONRPCException as e:
+            print(e.error['message'])
+            assert(False)
+        assert(iswl)
+
+        multiAddress1=self.nodes[1].createmultisig(2,[clientAddress1['pubkey'],clientAddress2['pubkey'],clientAddress3['pubkey']])
+
+        wl1file=self.initfile("wl1.dat")
+        self.nodes[1].dumpwhitelist(wl1file)
+
+        kycpubkey=self.nodes[0].getkycpubkey(self.nodes[1].getnewaddress())
+
+        #Adding the created p2sh to the whitelist via addmultitowhitelist rpc
+        self.nodes[1].addmultitowhitelist(multiAddress1['address'],[clientAddress1['derivedpubkey'],clientAddress2['derivedpubkey'],clientAddress3['derivedpubkey']],2,kycpubkey)
+        nwhitelisted+=1
+        wl1file_2=self.initfile("wl1_2.dat")
+        self.nodes[1].dumpwhitelist(wl1file_2)
+        nlines1=self.linecount(wl1file)
+        nlines2=self.linecount(wl1file_2)
+        assert_equal(nlines1+1,nlines2)
+
+        try:
+            iswl=self.nodes[1].querywhitelist(multiAddress1['address'])
+        except JSONRPCException as e:
+            print(e.error['message'])
+            assert(False)
+        assert(iswl)
+
+        if(clientAddress1['pubkey'] != clientAddress1['derivedpubkey']):
+            raise AssertionError("Pubkey and derived pubkey are not the same for a new address. Something is being tweaked when it shouldn't be.")
+        try:
+            multiAddress2=self.nodes[1].createmultisig(2,["asdasdasdasdasdas",clientAddress2['pubkey'],clientAddress4['pubkey']])
+            self.nodes[1].addmultitowhitelist(multiAddress2['address'],[clientAddress1['derivedpubkey'],clientAddress2['derivedpubkey'],clientAddress3['derivedpubkey']],2,kycpubkey)
+        except JSONRPCException as e:
+            assert("Invalid public key: asdasdasdasdasdas" in e.error['message'])
+        else:
+            raise AssertionError("P2SH multisig with an invalid first pubkey has been validated and accepted to the whitelist.")
+
+        try:
+            self.nodes[1].addmultitowhitelist("XKyFz4ezBfJPyeCuQNmDGZhF77m9PF1Jv2",[clientAddress1['derivedpubkey'],clientAddress2['derivedpubkey'],clientAddress3['derivedpubkey']],2,kycpubkey)
+        except JSONRPCException as e:
+            assert("invalid Bitcoin address: XKyFz4ezBfJPyeCuQNmDGZhF77m9PF1Jv2" in e.error['message'])
+        else:
+            raise AssertionError("P2SH multisig with an invalid address has been validated and accepted to the whitelist.")
+
+        try:
+            multiAddress2=self.nodes[1].createmultisig(4,[clientAddress1['pubkey'],clientAddress2['pubkey'],clientAddress4['pubkey']])
+            self.nodes[1].addmultitowhitelist(multiAddress2['address'],[clientAddress1['derivedpubkey'],clientAddress2['derivedpubkey'],clientAddress3['derivedpubkey']],2,kycpubkey)
+        except JSONRPCException as e:
+            assert("not enough keys supplied (got 3 keys, but need at least 4 to redeem)" in e.error['message'])
+        else:
+            raise AssertionError("P2SH multisig with n > m has been validated and accepted to the whitelist.")
+
+        try:
+            multiAddress2=self.nodes[1].createmultisig(0,[clientAddress1['pubkey'],clientAddress2['pubkey'],clientAddress3['pubkey']])
+            self.nodes[1].addmultitowhitelist(multiAddress2['address'],[clientAddress1['derivedpubkey'],clientAddress2['derivedpubkey'],clientAddress3['derivedpubkey']],2,kycpubkey)
+        except JSONRPCException as e:
+            assert("a multisignature address must require at least one key to redeem" in e.error['message'])
+        else:
+            raise AssertionError("P2SH multisig with n=0 has been validated and accepted to the whitelist.")
+
+
+        wl1_file=self.initfile("wl1.dat")
+        self.nodes[1].dumpwhitelist(wl1_file)
+
+        #Get kyc pubkey for node1 from node1 and node0
+        addr1=self.nodes[1].getnewaddress()
+        kycpub1=self.nodes[0].getkycpubkey(addr1)
+        assert_equal(kycpub1, self.nodes[1].getkycpubkey(addr1))
+
+        #Blacklist node1 wallet
+        self.nodes[0].blacklistkycpubkey(kycpub1)
+
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        wl1_bl_file=self.initfile("wl1_bl.dat")
+        self.nodes[1].dumpwhitelist(wl1_bl_file)
+
+        #The whitelist should now be empty
+        nlines=self.linecount(wl1_file)
+        nlines_bl=self.linecount(wl1_bl_file)
+
+        assert_equal(nlines-nlines_bl,nwhitelisted)
+
+        #Re-whitelist node1 wallet
+        kycpubkeyarr=[kycpub1]
+        self.nodes[0].whitelistkycpubkeys(kycpubkeyarr)
+
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        wl1file_rwl=self.initfile("wl1_rwl.dat")
+        self.nodes[1].dumpwhitelist(wl1file_rwl)
+        nlines_rwl=self.linecount(wl1file_rwl)
+        assert_equal(nlines_rwl, nlines)
+
+        maxpercall=100
+        #Whitelist more kycpubkeys
+        while len(kycpubkeyarr) < maxpercall:
+            kycpubkeyarr.append(kycpub1)
+
+        self.nodes[0].whitelistkycpubkeys(kycpubkeyarr)
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        #Test limit of nkeys per call
+        kycpubkeyarr.append(kycpub1)
+
+        try:
+            self.nodes[0].whitelistkycpubkeys(kycpubkeyarr)
+        except JSONRPCException as e:
+            assert("too many keys in input array" in e.error['message'])
+
+
+        #assert whitelist file are the same for the two nodes
+        wl0file=self.initfile(self.options.tmpdir+"wl0.dat")
+        self.nodes[0].dumpwhitelist(wl0file)
+
+        wl2file=self.initfile(self.options.tmpdir+"wl2.dat")
+        self.nodes[2].dumpwhitelist(wl2file)
+
+        assert(filecmp.cmp(wl0file, wl2file))
+
+        with open(wl0file, 'r') as fin0, open(wl2file, 'r') as fin2:
+            lines0=fin0.readlines()
+            lines2=fin2.readlines()
+
+            set0=set(lines0)
+            set2=set(lines2)
+
+            len0=len(set0)
+            len2=len(set2)
+
+
+            assert(len0 == len2)
+
+            diff0=set0.difference(set2)
+            diff2=set2.difference(set0)
+
+            lendiff0 = len(diff0)
+            lendiff2 = len(diff2)
+
+            assert(lendiff0 == 0)
+            assert(lendiff2 == 0)
+                
+
+        self.cleanup_files()
+        return
+
+if __name__ == '__main__':
+ OnboardTest().main()
+
+#  LocalWords:  ac

--- a/qa/rpc-tests/signcontract.py
+++ b/qa/rpc-tests/signcontract.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class SignContractTest (BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 4
+        self.extra_args = [['-usehd={:d}'.format(i%2==0), '-keypool=100'] for i in range(self.num_nodes)]
+#Node 1 is a whitelist node. 
+        self.extra_args[0].append("-pkhwhitelist=1")
+        self.extra_args[1].append("-pkhwhitelist=1")
+        self.extra_args[0].append("-contractintx=1")
+        self.extra_args[1].append("-contractintx=1")
+
+#Add keys from 'from_node' to the whitelist on 'whitelist_node'
+    def add_keys_to_whitelist(self,from_node, whitelist_node):
+        keys=from_node.getderivedkeys()
+        addresses=keys['address']
+        bpubkeys=keys['bpubkey']
+        for i in range(len(addresses)):
+            whitelist_node.addtowhitelist(addresses[i], bpubkeys[i])
+
+
+#Add keys from 'from_node' to the whitelist on 'whitelist_node' by dumping to a file and then reading it
+    def add_keys_to_whitelist_from_dumpfile(self,from_node, whitelist_node, filename):
+        dumpfile_name=self.options.tmpdir + filename
+        from_node.dumpderivedkeys(dumpfile_name)
+        whitelist_node.readwhitelist(dumpfile_name)
+     
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args[:self.num_nodes])
+        #Block signing node -- whitelist node -- client node
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,1,3)
+        connect_nodes_bi(self.nodes,2,3)
+        self.is_network_split=False
+        self.sync_all()
+
+    def clear_whitelists(self):
+        for node in self.nodes:
+            node.clearwhitelist()
+
+    #Count number of lines in file, removing commented and blank lines 
+    def num_keys_in_file(self, fname):
+        num_keys=0
+        for line in open(fname):
+            li=line.strip()
+            #The tweaked public addresses start with 2d
+            if li.startswith('2d'):
+                num_keys=num_keys+1
+        return num_keys
+
+    def run_test (self):
+        self.clear_whitelists()
+        self.add_keys_to_whitelist(self.nodes[0], self.nodes[0])
+        fname = self.options.tmpdir + 'node0whitelist'
+        self.nodes[0].dumpwhitelist(fname)
+        num_keys=self.num_keys_in_file(fname)
+        assert_equal(num_keys,100)
+        self.add_keys_to_whitelist(self.nodes[1], self.nodes[1])
+        fname = self.options.tmpdir + 'node1whitelist'
+        self.nodes[1].dumpwhitelist(fname)
+        num_keys=self.num_keys_in_file(fname)
+        assert_equal(num_keys,100)
+        #dumo derived keys to file and validate 
+        fname = self.options.tmpdir + 'node1derived'
+        self.nodes[1].dumpderivedkeys(fname)
+        with open(fname, 'r') as myfile:
+            print(myfile.read())
+        self.nodes[1].validatederivedkeys(fname)
+        #add in invalid key/addesss pair to the file and validate again 
+        a_key='2dZbsQ9Wbgck2HVeJcnUHRKPgFqf1fRbDvs'
+        a_key_address_invalid='0289666bb0ccafc11ba82c057e6a7599fdb5a1be2e348f1db33e3c6af2fc27550c'
+        with open(fname, 'a') as myfile:
+            myfile.write(a_key + " " + a_key_address_invalid)
+        #expect a invalid key id error
+        print(self.nodes[1].getcontract())
+        print(self.nodes[1].getcontracthash())
+        try:
+            self.nodes[1].validatederivedkeys(fname)
+        except JSONRPCException as e:
+            assert("Invalid key idx" in e.error['message'])
+          
+        # Check that there's 100 UTXOs on each of the nodes
+        assert_equal(len(self.nodes[0].listunspent()), 100)
+        assert_equal(len(self.nodes[1].listunspent()), 100)
+        assert_equal(len(self.nodes[2].listunspent()), 100)
+
+        print("Before mining blocks - balance = 21000000")
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['balance']["CBT"], 21000000)
+
+        print("Mining blocks...")
+        self.nodes[1].generate(101)
+        self.sync_all()
+
+        print("Check balances")
+        for i in range(len(self.nodes)):
+            assert_equal(self.nodes[i].getbalance("", 0, False, "CBT"), 21000000)
+
+        #Set all OP_TRUE genesis outputs to the signing node
+        print("Set all the OP_TRUE genesis outputs to a single node.")
+        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 21000000, "", "", True)
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        print("Check balance - now node0 should have 21000000, others should have 0.")
+        #Check signing node.
+        assert_equal(self.nodes[0].getbalance("", 0, False, "CBT"), 21000000)
+        #Check the rest of the nodes.
+        for i in range(len(self.nodes)):
+            if(i==0):
+                continue
+            assert_equal(self.nodes[i].getbalance("", 0, False, "CBT"), 0)
+       
+        # issue some new asset (that is not the policy asset)
+        issue = self.nodes[0].issueasset('100.0','0')
+        self.nodes[1].generate(1)
+
+        # Send 21 issued asset from 0 to 2 using sendtoaddress. Will fail to create mempool transaction because recipient addresses not whitelisted.
+        print(self.nodes[0].getwalletinfo())
+        print("Sending 21 issued asset from 0 to 2 using sendtoaddress.")
+        txid1 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11,"","",False,issue["asset"])
+        txout1v0 = self.nodes[0].gettxout(txid1, 0)
+        self.nodes[1].generate(101)
+        self.sync_all()
+        try:
+            rawtx1 = self.nodes[1].getrawtransaction(txid1, 1)
+            print("Raw trans:")
+            print(rawtx1)
+        except JSONRPCException as e:
+            assert("No such mempool transaction" in e.error['message'])
+            #Abandon the transaction to allow the output to be respent
+            self.nodes[0].abandontransaction(txid1)
+        else:
+            raise AssertionError("Output accepted to non-whitelisted address.")
+
+
+        txid2 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10,"","",False,issue["asset"])
+        txout2v0 = self.nodes[0].gettxout(txid2, 0)
+        self.nodes[1].generate(101)
+        self.sync_all()
+        try:
+            rawtx2 = self.nodes[1].getrawtransaction(txid2, 1)
+        except JSONRPCException as e:
+            assert("No such mempool transaction" in e.error['message'])
+            #Abandon the transaction to allow the output to be respent
+            self.nodes[0].abandontransaction(txid2)
+        else:
+            raise AssertionError("Output accepted to non-whitelisted address.")
+
+        #query whitelist
+        node2_test_address = self.nodes[2].getnewaddress()
+        
+        assert_equal(self.nodes[0].querywhitelist(node2_test_address), False)
+        #add node2 to whitelist
+        self.add_keys_to_whitelist(self.nodes[2], self.nodes[0])
+        self.add_keys_to_whitelist(self.nodes[2], self.nodes[1])
+        #query whitelist
+        node2_test_address = self.nodes[2].getnewaddress()
+        print(node2_test_address)
+        assert_equal(self.nodes[0].querywhitelist(node2_test_address), True)
+        #remove an address from the whitelist
+        self.nodes[0].removefromwhitelist(node2_test_address)
+        #address no longer in whitelist
+        assert_equal(self.nodes[0].querywhitelist(node2_test_address), False)
+        #next available address still in whitelist
+        assert_equal(self.nodes[0].querywhitelist(self.nodes[2].getnewaddress()), True)
+        
+        # Send 21 BTC from 0 to 2 using sendtoaddress
+        print("Sending 21 issued asset from 0 to 2 using sendtoaddress")
+        print(self.nodes[0].getwalletinfo())
+        txid1 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11,"","",False,issue["asset"])
+        txout1v0 = self.nodes[0].gettxout(txid1, 0)
+        rawtx1 = self.nodes[0].getrawtransaction(txid1, 1)
+        #amountcommit1 = rawtx1["vout"][0]["amountcommitment"]
+        assert_equal(txout1v0['confirmations'], 0)
+        assert(not txout1v0['coinbase'])
+        #assert_equal(amountcommit1, txout1v0['amountcommitment'])
+
+
+        txid2 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10,"","",False,issue["asset"])
+        txout2v0 = self.nodes[0].gettxout(txid2, 0)
+        rawtx2 = self.nodes[0].getrawtransaction(txid2, 1)
+        #amountcommit2 = rawtx2["vout"][0]["amountcommitment"]
+        assert_equal(txout2v0['confirmations'], 0)
+        assert(not txout2v0['coinbase'])
+        #assert_equal(amountcommit2, txout2v0['amountcommitment'])
+
+        walletinfo = self.nodes[0].getwalletinfo(issue["asset"])
+        assert_equal(walletinfo['immature_balance'], 0)
+
+        # Have node1 mine 101 blocks
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        assert_equal(self.nodes[0].getbalance("", 0, False, issue["asset"]), 100-21)
+        assert_equal(self.nodes[2].getbalance("", 0, False, issue["asset"]), 21)
+
+
+        #check that dumpwhitelist dumps the correct number of keys
+        fname = self.options.tmpdir + 'node0whitelist'
+        self.nodes[0].dumpwhitelist(fname)
+        num_keys=self.num_keys_in_file(fname)
+        #expected N_keys is 199 because one key was removed using removekey
+        assert_equal(num_keys, 199)
+
+        #clear whitelists and check number of keys in wl = 0 and that we cannot send to previously whitelisted address 
+        self.clear_whitelists()
+        self.nodes[0].dumpwhitelist(fname)
+        num_keys=num_keys=self.num_keys_in_file(fname)
+        assert_equal(num_keys, 0)
+        print(self.nodes[0].getwalletinfo("CBT"))
+        print("Sending 21 BTC from 0 to 2 using sendtoaddress.")
+        txid1 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11,"","",False,issue["asset"])
+        txout1v0 = self.nodes[0].gettxout(txid1, 0)
+        try:
+            rawtx1 = self.nodes[0].getrawtransaction(txid1, 1)
+            print(rawtx1)
+        except JSONRPCException as e:
+            assert("No such mempool transaction" in e.error['message'])
+            #Abandon the transaction to allow the output to be respent
+            self.nodes[0].abandontransaction(txid1)
+        else:
+            raise AssertionError("Output accepted to non-whitelisted address.")
+
+        txid2 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10,"","",False,issue["asset"])
+        txout2v0 = self.nodes[0].gettxout(txid2, 0)
+        try:
+            rawtx2 = self.nodes[0].getrawtransaction(txid2, 1)
+        except JSONRPCException as e:
+            assert("No such mempool transaction" in e.error['message'])
+            #Abandon the transaction to allow the output to be respent
+            self.nodes[0].abandontransaction(txid2)
+        else:
+            raise AssertionError("Output accepted to non-whitelisted address.")
+
+        #add node2 to whitelist from file dump and try sending coins again
+#        self.add_keys_to_whitelist_from_dumpfile(self.nodes[2], self.nodes[0], 'keys20')
+#        self.add_keys_to_whitelist_from_dumpfile(self.nodes[2], self.nodes[1], 'keys21')
+        self.add_keys_to_whitelist(self.nodes[0], self.nodes[0])
+        self.add_keys_to_whitelist(self.nodes[1], self.nodes[1])
+        self.add_keys_to_whitelist(self.nodes[2], self.nodes[0])
+        self.add_keys_to_whitelist(self.nodes[2], self.nodes[1])
+
+        # Send 21 BTC from 0 to 2 using sendtoaddress
+        print("Sending 21 BTC from 0 to 2 using sendtoaddress")
+        print(self.nodes[0].getwalletinfo("CBT"))
+        txid1 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11,"","",False,issue["asset"])
+        txout1v0 = self.nodes[0].gettxout(txid1, 0)
+        rawtx1 = self.nodes[0].getrawtransaction(txid1, 1)
+        #amountcommit1 = rawtx1["vout"][0]["amountcommitment"]
+        assert_equal(txout1v0['confirmations'], 0)
+        assert(not txout1v0['coinbase'])
+        #assert_equal(amountcommit1, txout1v0['amountcommitment'])
+
+
+        txid2 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10,"","",False,issue["asset"])
+        txout2v0 = self.nodes[0].gettxout(txid2, 0)
+        rawtx2 = self.nodes[0].getrawtransaction(txid2, 1)
+        #amountcommit2 = rawtx2["vout"][0]["amountcommitment"]
+        assert_equal(txout2v0['confirmations'], 0)
+        assert(not txout2v0['coinbase'])
+        #assert_equal(amountcommit2, txout2v0['amountcommitment'])
+
+        walletinfo = self.nodes[0].getwalletinfo("CBT")
+        assert_equal(walletinfo['immature_balance'], 0)
+
+        # Have node1 mine 101 blocks
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        assert_equal(self.nodes[0].getbalance("", 0, False, issue["asset"]), 100-42)
+        assert_equal(self.nodes[2].getbalance("", 0, False, issue["asset"]), 42)
+
+        print("End.")
+
+if __name__ == '__main__':
+    SignContractTest().main()

--- a/qa/rpc-tests/signcontract.py
+++ b/qa/rpc-tests/signcontract.py
@@ -18,6 +18,10 @@ class SignContractTest (BitcoinTestFramework):
         self.extra_args[1].append("-pkhwhitelist=1")
         self.extra_args[0].append("-contractintx=1")
         self.extra_args[1].append("-contractintx=1")
+        self.extra_args[0].append("-regtest=0")
+        self.extra_args[1].append("-regtest=0")
+        self.extra_args[2].append("-regtest=0")
+        self.extra_args[3].append("-regtest=0")       
 
 #Add keys from 'from_node' to the whitelist on 'whitelist_node'
     def add_keys_to_whitelist(self,from_node, whitelist_node):
@@ -84,6 +88,7 @@ class SignContractTest (BitcoinTestFramework):
         #expect a invalid key id error
         print(self.nodes[1].getcontract())
         print(self.nodes[1].getcontracthash())
+        assert(False)
         try:
             self.nodes[1].validatederivedkeys(fname)
         except JSONRPCException as e:

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -165,6 +165,7 @@ protected:
         fDefaultConsistencyChecks = GetBoolArg("-fdefaultconsistencychecks", true);
         fRequireStandard = GetBoolArg("-frequirestandard", false);
         fEmbedContract = GetBoolArg("-embedcontract", DEFAULT_EMBED_CONTRACT);
+        fContractInTx = GetBoolArg("-contractintx", DEFAULT_CONTRACT_INTX);
         fEmbedMapping = GetBoolArg("-embedmapping", DEFAULT_EMBED_MAPPING);
         fMineBlocksOnDemand = GetBoolArg("-fmineblocksondemand", true);
         anyonecanspend_aremine = GetBoolArg("-anyonecanspendaremine", true);

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -131,7 +131,7 @@ protected:
     bool fDefaultConsistencyChecks;
     bool fRequireStandard;
     bool fMineBlocksOnDemand;
-    bool fContractInTx
+    bool fContractInTx;
     bool fEmbedContract;
     bool fEmbedMapping;
     CCheckpointData checkpointData;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -39,6 +39,7 @@ struct ChainTxData {
 };
 
 static const bool DEFAULT_EMBED_CONTRACT = true;
+static const bool DEFAULT_CONTRACT_INTX = false;
 static const bool DEFAULT_EMBED_MAPPING = true;
 
 /**
@@ -83,8 +84,10 @@ public:
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
     /** Policy: Filter transactions that do not match well-defined patterns */
     bool RequireStandard() const { return fRequireStandard; }
+    /** Configuration option to include the contract in transactions and enforce as a mempool policy */
+    bool ContractInTx() const { return fContractInTx; }
     /** Configuration option to include the contract hash in block and address generation */
-    bool EmbedContract() const { return fEmbedContract; }
+    bool EmbedContract() const { return fEmbedContract; }    
     /** Configuration option to include the mapping hash in block */
     bool EmbedMapping() const { return fEmbedMapping; }
     uint64_t PruneAfterHeight() const { return nPruneAfterHeight; }
@@ -128,6 +131,7 @@ protected:
     bool fDefaultConsistencyChecks;
     bool fRequireStandard;
     bool fMineBlocksOnDemand;
+    bool fContractInTx
     bool fEmbedContract;
     bool fEmbedMapping;
     CCheckpointData checkpointData;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -503,6 +503,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-embedmapping", _("Embed asset mapping object in the block header"));
     strUsage += HelpMessageOpt("-issuecontrolscript", _("Embed the issuance controller script in the genesis block"));
     strUsage += HelpMessageOpt("-recordinflation", _("Record issuance data and freeze history"));
+    strUsage += HelpMessageOpt("-contractintx", _("Enforce contract in transaction with null tweaking"));
 
     strUsage += HelpMessageGroup(_("RPC server options:"));
     strUsage += HelpMessageOpt("-server", _("Accept command line and JSON-RPC commands"));

--- a/src/policy/kycfile.cpp
+++ b/src/policy/kycfile.cpp
@@ -175,10 +175,12 @@ void CKYCFile::parsePubkeyPair(const std::vector<std::string> vstr, const std::s
 
     //Check the key tweaking
     CKeyID addressKeyId;
-    if(address.GetKeyID(addressKeyId) && !Params().ContractInTx()){
-        if(!Consensus::CheckValidTweakedAddress(addressKeyId, pubKey)){
-            _decryptedStream << line << ": invalid key tweaking\n";
-            return;
+    if(address.GetKeyID(addressKeyId)){
+        if(!Params().ContractInTx()){
+            if(!Consensus::CheckValidTweakedAddress(addressKeyId, pubKey)){
+                _decryptedStream << line << ": invalid key tweaking\n";
+                return;
+            }
         }
     }
     else{
@@ -226,10 +228,12 @@ void CKYCFile::parseMultisig(const std::vector<std::string> vstr, const std::str
     //Will throw an error if address is not a valid derived address.
     CTxDestination multiKeyId;
     multiKeyId = address.Get();
-    if (!(multiKeyId.which() == ((CTxDestination)CNoDestination()).which()) && !Params().ContractInTx()){
-        if(!Consensus::CheckValidTweakedAddress(multiKeyId, pubKeys, nMultisig)){
-            _decryptedStream << line << ": invalid key tweaking\n";
-            return;
+    if (!(multiKeyId.which() == ((CTxDestination)CNoDestination()).which())) {
+        if(!Params().ContractInTx()){
+            if(!Consensus::CheckValidTweakedAddress(multiKeyId, pubKeys, nMultisig)){
+                _decryptedStream << line << ": invalid key tweaking\n";
+                return;
+            }
         }
     }
     else{

--- a/src/policy/kycfile.cpp
+++ b/src/policy/kycfile.cpp
@@ -175,7 +175,7 @@ void CKYCFile::parsePubkeyPair(const std::vector<std::string> vstr, const std::s
 
     //Check the key tweaking
     CKeyID addressKeyId;
-    if(address.GetKeyID(addressKeyId)){
+    if(address.GetKeyID(addressKeyId) && !Params().ContractInTx()){
         if(!Consensus::CheckValidTweakedAddress(addressKeyId, pubKey)){
             _decryptedStream << line << ": invalid key tweaking\n";
             return;
@@ -226,7 +226,7 @@ void CKYCFile::parseMultisig(const std::vector<std::string> vstr, const std::str
     //Will throw an error if address is not a valid derived address.
     CTxDestination multiKeyId;
     multiKeyId = address.Get();
-    if (!(multiKeyId.which() == ((CTxDestination)CNoDestination()).which())){
+    if (!(multiKeyId.which() == ((CTxDestination)CNoDestination()).which()) && !Params().ContractInTx()){
         if(!Consensus::CheckValidTweakedAddress(multiKeyId, pubKeys, nMultisig)){
             _decryptedStream << line << ": invalid key tweaking\n";
             return;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -182,6 +182,28 @@ bool IsPolicy(const CAsset& asset){
     return false;
 }
 
+bool IsContractInTx(CTransaction const &tx) {
+  txnouttype whichType;
+  uint256 contract = chainActive.Tip() ? chainActive.Tip()->hashContract : GetContractHash();
+
+  for (CTxOut const &txout : tx.vout) {
+    opcodetype opcode;
+    std::vector<unsigned char> bytes;
+    vector<vector<uint8_t>> vSolutions;
+    if (!Solver(txout.scriptPubKey, whichType, vSolutions))
+      return false;
+    if(whichType == TX_NULL_DATA) {
+      CScript::const_iterator pc = txout.scriptPubKey.begin();
+      if (!txout.scriptPubKey.GetOp(++pc, opcode, bytes)) continue;
+      if(bytes.size() == 32) {
+        uint256 data(bytes)
+        if(data == contract) return true
+      }
+    }
+  }
+  return false;
+}
+
 // @fn IsWhitelisted
 // @brief determines that all outputs of a transaction are P2PKH,
 //        all output addresses must be in the whitelist database.

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -196,8 +196,8 @@ bool IsContractInTx(CTransaction const &tx) {
       CScript::const_iterator pc = txout.scriptPubKey.begin();
       if (!txout.scriptPubKey.GetOp(++pc, opcode, bytes)) continue;
       if(bytes.size() == 32) {
-        uint256 data(bytes)
-        if(data == contract) return true
+        uint256 data(bytes);
+        if(data == contract) return true;
       }
     }
   }

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -136,6 +136,11 @@ bool IsPolicy(const CTransaction& tx);
 bool IsAllPolicy(const CTransaction& tx);
 
 /**
+ * Check if the transaction contains the contract hash as an OP_RETURN output
+ */
+bool IsContractInTx(const CTransaction& tx);
+
+/**
  * Check all type and whitelist status of outputs of tx
  * Return true if all outputs of tx are type TX_PUBKEYHASH and all PUBKEYHASHes are present in the whitelist database
  */

--- a/src/policy/whitelist.cpp
+++ b/src/policy/whitelist.cpp
@@ -128,7 +128,7 @@ void CWhiteList::add_derived(const CBitcoinAddress& address,  const CPubKey& pub
 
   CPubKey tweakedPubKey(pubKey);
    uint256 contract = chainActive.Tip() ? chainActive.Tip()->hashContract : GetContractHash();
-  if (!contract.IsNull())
+  if (!contract.IsNull() && !Params().ContractInTx())
     tweakedPubKey.AddTweakToPubKey((unsigned char*)contract.begin());
     _tweakedPubKeyMap[boost::get<CKeyID>(keyId)]=tweakedPubKey;
 

--- a/src/policy/whitelist.cpp
+++ b/src/policy/whitelist.cpp
@@ -97,7 +97,7 @@ void CWhiteList::add_derived(const CBitcoinAddress& address,  const CPubKey& pub
       throw std::invalid_argument(std::string(std::string(__func__) + 
       ": invalid key id"));
 
-  if(!Consensus::CheckValidTweakedAddress(keyId, pubKey))
+  if(!Params().ContractInTx() && !Consensus::CheckValidTweakedAddress(keyId, pubKey))
      throw std::invalid_argument(std::string(std::string(__func__) + 
       ": address does not derive from public key when tweaked with contract hash"));
 
@@ -195,7 +195,7 @@ void CWhiteList::add_multisig_whitelist(const CBitcoinAddress& address, const st
     kycKeyId=kycPubKey->GetID();
   }
 
-  if(!Consensus::CheckValidTweakedAddress(keyId, pubKeys, nMultisig))
+  if(!Params().ContractInTx() && !Consensus::CheckValidTweakedAddress(keyId, pubKeys, nMultisig))
      throw std::invalid_argument(std::string(std::string(__func__) + 
       ": address does not derive from public keys when tweaked with contract hash"));
 

--- a/src/script/registeraddressscript.cpp
+++ b/src/script/registeraddressscript.cpp
@@ -51,7 +51,7 @@ bool CRegisterAddressScript::Append(const CPubKey& pubKey){
 	uint256 contract = chainActive.Tip() ? chainActive.Tip()->hashContract : GetContractHash();
 
   	CPubKey tweakedPubKey(pubKey);
-    if (!contract.IsNull())
+    if (!contract.IsNull() && !Params().ContractInTx())
     	tweakedPubKey.AddTweakToPubKey((unsigned char*)contract.begin());
     CKeyID keyID=tweakedPubKey.GetID();
     if(!Params().ContractInTx() && !Consensus::CheckValidTweakedAddress(keyID, pubKey))

--- a/src/script/registeraddressscript.cpp
+++ b/src/script/registeraddressscript.cpp
@@ -54,7 +54,7 @@ bool CRegisterAddressScript::Append(const CPubKey& pubKey){
     if (!contract.IsNull())
     	tweakedPubKey.AddTweakToPubKey((unsigned char*)contract.begin());
     CKeyID keyID=tweakedPubKey.GetID();
-    if(!Consensus::CheckValidTweakedAddress(keyID, pubKey))
+    if(!Params().ContractInTx() && !Consensus::CheckValidTweakedAddress(keyID, pubKey))
         return false;
     
     std::vector<unsigned char> vKeyIDNew = ToByteVector(keyID);
@@ -84,7 +84,7 @@ bool CRegisterAddressScript::Append(const uint8_t nMultisig, const CTxDestinatio
     if(whitelistType != RA_MULTISIG && whitelistType != RA_ONBOARDING)
         return false;
 
-    if (!(Consensus::CheckValidTweakedAddress(keyID, keys, nMultisig)))
+    if (!Params().ContractInTx() && !(Consensus::CheckValidTweakedAddress(keyID, keys, nMultisig)))
         return false;
     
     _payload.insert(_payload.end(), 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -83,6 +83,7 @@ bool fHavePruned = false;
 bool fPruneMode = false;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 bool fRequireStandard = true;
+bool fContractInTx = false;
 bool fRequireWhitelistCheck = DEFAULT_WHITELIST_CHECK;
 bool fScanWhitelist = DEFAULT_SCAN_WHITELIST;
 bool fEnableBurnlistCheck = DEFAULT_BURNLIST_CHECK;
@@ -1094,6 +1095,10 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool, CValidationState &state,
   if (fRequireWhitelistCheck)
     if (!IsAllBurn(tx) && !IsPolicy(tx) && !IsWhitelisted(tx) && !test_accept)
       return state.DoS(0, false, REJECT_NONSTANDARD, "non-whitelisted-address");
+  // Accept only transactions that include a hash of the latest contract
+  if (fContractInTx)
+      if(!IsAllBurn(tx) && !IsPolicy(tx) && !IsContractInTx(tx))
+        return state.DoS(0, false, REJECT_NONSTANDARD, "contract-missing");
   // Only accept nLockTime-using transactions that can be mined in the next
   // block; we don't want our mempool filled up with transactions that can't
   // be mined yet.

--- a/src/validation.h
+++ b/src/validation.h
@@ -224,6 +224,7 @@ extern bool fblockissuancetx;
 extern bool fRecordInflation;
 extern bool fRequestList;
 extern bool fRequireStandard;
+extern bool fContractInTx;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -464,7 +464,7 @@ UniValue validatederivedkeys(const JSONRPCRequest& request)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid public key");
 
         uint256 contract = chainActive.Tip() ? chainActive.Tip()->hashContract : GetContractHash();
-        if (!contract.IsNull())
+        if (!contract.IsNull() && !Params().ContractInTx())
             pubKey.AddTweakToPubKey((unsigned char*)contract.begin());
         CKeyID keyId;
         if (!address.GetKeyID(keyId))
@@ -870,7 +870,7 @@ UniValue createkycfile(const JSONRPCRequest& request)
 
         std::vector<CPubKey> tweakedPubKeys = pubKeyVec;
 
-        if (!contract.IsNull()){
+        if (!contract.IsNull() && !Params().ContractInTx()){
             for (unsigned int it = 0; it < tweakedPubKeys.size(); ++it){
                 tweakedPubKeys[it].AddTweakToPubKey((unsigned char*)contract.begin());
             }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3349,6 +3349,16 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
             }
         }
 
+        //add contract hash to transaction if option selected
+        if(Params().ContractInTx()) {
+            uint256 contract = chainActive.Tip() ? chainActive.Tip()->hashContract : GetContractHash();
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN;
+            scriptPubKey << std::vector<unsigned char>(contract.begin(), contract.end());
+            CTxOut txoutcontract(feeAsset,0,scriptPubKey);
+            txNew.vout.push_back(txoutcontract);
+        }
+
         // TODO Do actual blinding/caching here to allow for amount adjustments until end
         if (sign)
         {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -119,7 +119,7 @@ CPubKey CWallet::GenerateNewKey()
     if (Params().EmbedContract()) {
         // use the active block contract hash to generate keys - if this is not available use the local contract
         uint256 contract = chainActive.Tip() ? chainActive.Tip()->hashContract : GetContractHash(); // for BIP-175
-        if (!contract.IsNull())
+        if (!contract.IsNull() && !Params().ContractInTx())
         {
             pubKeyPreTweak.AddTweakToPubKey((unsigned char*)contract.begin()); //tweak pubkey for reverse testing
             secret.AddTweakToPrivKey((unsigned char*)contract.begin()); //do actual tweaking of private key


### PR DESCRIPTION
Config option to include the contract hash in transactions instead of via tweaking. 

Onboarding and whitelisting remains the same, however if contractintx=1, the supplied public keys must correspond the the address without tweaking. 

The wallet does not tweak keys for onboarding. 

sendtoaddress adds the contract hash as a zero value OP_RETURN to all transactions. 

All non-policy and non-burn transactions are checked that they include the contract hash as an OP_RETURN output before accepting to the mempool. 