### PR TITLE
Recover keys

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -116,6 +116,7 @@ testScripts = [
     'onboard_cit.py',
     'onboardmanual.py',
     'onboardmanual_cit.py',
+    'recoverencryptionkeys.py',
     'fixedfee.py',
     # Accounts not supported
     #'wallet-accounts.py',

--- a/qa/rpc-tests/onboardmanual_cit.py
+++ b/qa/rpc-tests/onboardmanual_cit.py
@@ -846,7 +846,6 @@ class OnboardManualCITTest (BitcoinTestFramework):
         
         #Check that all the addresses in the kycfiles are whitelisted
         for file in self.files:
-             print("Validating kycfile: " + str(file))
             valkyc=self.nodes[0].validatekycfile(file, True)
             if len(valkyc["addresses"]) > 0:
                 assert(valkyc["iswhitelisted"] == True)

--- a/qa/rpc-tests/recoverencryptionkeys.py
+++ b/qa/rpc-tests/recoverencryptionkeys.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import filecmp
+import time
+import string
+import urllib.parse
+import array as arr
+
+class RecoverEncryptionKeysTest (BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 4
+        self.extra_args = [['-txindex'] for i in range(4)]
+        self.extra_args[0].append("-contractintx=1")
+        self.extra_args[0].append("-pkhwhitelist=1")
+        self.extra_args[0].append("-pkhwhitelist-encrypt=0")
+        self.extra_args[0].append("-initialfreecoins=2100000000000000")
+        self.extra_args[0].append("-policycoins=50000000000000")
+        self.extra_args[0].append("-regtest=0")
+        self.extra_args[0].append("-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[0].append("-whitelistcoinsdestination=76a914427bf8530a3962ed77fd3c07d17fd466cb31c2fd88ac")
+        self.extra_args[1].append("-contractintx=1")
+        self.extra_args[1].append("-regtest=0")
+        self.extra_args[1].append("-pkhwhitelist=1")
+        self.extra_args[1].append("-pkhwhitelist-encrypt=0")
+        self.extra_args[1].append("-initialfreecoins=2100000000000000")
+        self.extra_args[1].append("-policycoins=50000000000000")
+        self.extra_args[1].append("-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[1].append("-whitelistcoinsdestination=76a914427bf8530a3962ed77fd3c07d17fd466cb31c2fd88ac")
+        self.extra_args[2].append("-contractintx=1")
+        self.extra_args[2].append("-regtest=0")
+        self.extra_args[2].append("-pkhwhitelist=1")
+        self.extra_args[2].append("-pkhwhitelist-encrypt=0")
+        self.extra_args[2].append("-initialfreecoins=2100000000000000")
+        self.extra_args[2].append("-policycoins=50000000000000")
+        self.extra_args[2].append("-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[2].append("-whitelistcoinsdestination=76a914427bf8530a3962ed77fd3c07d17fd466cb31c2fd88ac")
+        self.extra_args[3].append("-contractintx=1")
+        self.extra_args[3].append("-regtest=0")
+        self.extra_args[3].append("-pkhwhitelist=1")
+        self.extra_args[3].append("-pkhwhitelist-encrypt=0")
+        self.extra_args[3].append("-initialfreecoins=2100000000000000")
+        self.extra_args[3].append("-policycoins=50000000000000")
+        self.extra_args[3].append("-initialfreecoinsdestination=76a914bc835aff853179fa88f2900f9003bb674e17ed4288ac")
+        self.extra_args[3].append("-whitelistcoinsdestination=76a914427bf8530a3962ed77fd3c07d17fd466cb31c2fd88ac")
+        self.files=[]
+
+    def connect_nodes(self):
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,0,2)
+        connect_nodes_bi(self.nodes,2,3)
+        
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(4, self.options.tmpdir, self.extra_args[:4])
+        self.connect_nodes()
+        self.is_network_split=True
+        self.sync_all()
+
+        #Set up wallet path and dump the wallet
+        wlwalletname="wlwallet.dat"
+        self.wlwalletpath=self.initfile(os.path.join(self.options.tmpdir,wlwalletname))
+        self.nodes[0].backupwallet(self.wlwalletpath)
+
+        #Stop the nodes
+        stop_nodes(self.nodes)
+
+        #Copy the wallet file to the node 0 and 3 data dirs
+        #Give nodes 0 and 3 the same wallet (whitelist wallet)
+        node0path=os.path.join(self.options.tmpdir, "node"+str(0))
+        node3path=os.path.join(self.options.tmpdir, "node"+str(3))
+
+        self.dest0=self.initfile(os.path.join(node0path, "ocean_test"))
+        self.dest0=self.initfile(os.path.join(self.dest0, wlwalletname))
+        self.dest3=self.initfile(os.path.join(node3path, "ocean_test"))
+        self.dest3=self.initfile(os.path.join(self.dest3, wlwalletname))
+
+        shutil.copyfile(self.wlwalletpath,self.dest0)
+        shutil.copyfile(self.wlwalletpath,self.dest3)
+
+        #Start the nodes again with a different wallet path argument
+        self.extra_args[0].append("-wallet="+wlwalletname)
+        self.extra_args[3].append("-wallet="+wlwalletname)
+        self.nodes = start_nodes(4, self.options.tmpdir, self.extra_args[:4])
+
+        time.sleep(5)
+
+        #Node0 and node3 wallets should be the same
+        addr0=self.nodes[0].getnewaddress()
+        addr3=self.nodes[3].getnewaddress()
+
+        assert(addr0 == addr3)
+
+        self.connect_nodes()
+        self.is_network_split=False
+        self.sync_all()
+        
+    def linecount(self, file):
+        nlines=0
+        with open(file) as f:
+            for nlines, l in enumerate(f):
+                pass
+        return nlines
+
+    def initfile(self, filename):
+        self.files.append(filename)
+        self.removefileifexists(filename)
+        return filename
+
+    def removefileifexists(self, filename):
+        if filename in self.files:
+            self.files.remove(filename)
+        if(os.path.isfile(filename)):
+            os.remove(filename)
+        
+
+    def cleanup_files(self):
+        for file in self.files:
+            self.removefileifexists(file)
+
+
+    def get_nmine(self, kycpubkeysfile):
+        nmine=0
+        kycpk=''
+        kycpk_address=''
+        with open(kycpubkeysfile) as fp:
+            for line in fp:
+                if line[0] == '#':
+                    continue
+                sline=line.split(' ')
+                if len(sline) == 3:
+                    if int(sline[2]) == int(1):
+                        kycpk_address=sline[0]
+                        kycpk=sline[1]
+                        nmine=nmine+1
+        return nmine, kycpk_address, kycpk
+
+            
+    def run_test (self):
+        # import the policy keys into node 0
+        self.nodes[0].importprivkey("cS29UJMQrpnee7UaUHo6NqJVpGr35TEqUDkKXStTnxSZCGUWavgE")
+        self.nodes[0].importprivkey("cNCQhCnpnzyeYh48NszsTJC2G4HPoFMZguUnUgBpJ5X9Vf2KaPYx")
+
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        
+        #Add somekycpubkeys
+        nkeys=200
+        nkeys_part=100
+        for i in range(int(nkeys/nkeys_part)):
+            n=int((i+1)*nkeys_part)
+            self.nodes[0].topupkycpubkeys(n)
+            self.nodes[0].generate(1)
+            self.sync_all()
+
+        assert_equal(self.nodes[0].getnunassignedkycpubkeys(),nkeys)
+        assert_equal(self.nodes[3].getnunassignedkycpubkeys(),nkeys)
+        
+        #Restart node
+        self.stop_node(0)
+        time.sleep(2)
+
+        bConnected=True
+        try:
+            self.nodes[0].getblockcount()
+        except ConnectionRefusedError as e:
+            bConnected=False
+
+        assert_equal(bConnected, False)
+            
+        self.nodes[0] = start_node(0, self.options.tmpdir, self.extra_args[0])
+            
+        time.sleep(1)
+        self.connect_nodes()
+
+        self.sync_all()
+
+        #Check we still have the correct number of kycpubkeys
+        assert_equal(self.nodes[0].getnunassignedkycpubkeys(),nkeys)
+        assert_equal(self.nodes[3].getnunassignedkycpubkeys(),nkeys)
+        
+        #Check we still have the private keys for the kycpubkeys
+        kycpubkeysfile=self.initfile(os.path.join(self.options.tmpdir,"kycpubkeys.dat"))
+
+        self.nodes[0].dumpkycpubkeys(kycpubkeysfile)
+        
+        nmine, kycpk_address, kycpk=self.get_nmine(kycpubkeysfile)
+
+        assert(nmine == nkeys)
+
+        #Confirm node3 has not generated the kyc keys yet 
+        self.nodes[3].dumpkycpubkeys(kycpubkeysfile)
+        nmine, dum1, dum2=self.get_nmine(kycpubkeysfile)
+        assert(nmine == 0)
+
+        #Recover one kycpubkey
+        val=self.nodes[3].validateaddress(kycpk_address)
+        assert(val['ismine'] == False)
+        assert(self.nodes[3].recoverencryptionkey(kycpk, nkeys))
+        val=self.nodes[3].validateaddress(kycpk_address)
+        assert(val['ismine'] == True)
+
+        #Recover all pubkeys node0 
+        assert(self.nodes[0].recoverkyckeys())
+        #Confirm recovered
+        self.nodes[0].dumpkycpubkeys(kycpubkeysfile)
+        nmine, dum1, dum2=self.get_nmine(kycpubkeysfile)
+        assert(nmine == nkeys)
+
+        #Recover all pubkeys node 3
+        assert(self.nodes[3].recoverkyckeys(nkeys))
+            
+        #Confirm recovered
+        self.nodes[3].dumpkycpubkeys(kycpubkeysfile)
+        nmine, dum1, dum2=self.get_nmine(kycpubkeysfile)
+        assert(nmine == nkeys)
+
+        #Restart node0 and check the wallet still has the kyc keys
+        #Restart node
+        self.stop_node(3)
+        time.sleep(2)
+
+        bConnected=True
+        try:
+            self.nodes[3].getblockcount()
+        except ConnectionRefusedError as e:
+            bConnected=False
+
+        assert_equal(bConnected, False)
+            
+        self.nodes[3] = start_node(3, self.options.tmpdir, self.extra_args[3])
+            
+        time.sleep(1)
+        self.connect_nodes()
+        self.sync_all()
+        self.nodes[3].dumpkycpubkeys(kycpubkeysfile)
+        nmine, dum1, dum2=self.get_nmine(kycpubkeysfile)
+        assert(nmine == nkeys)
+        
+        self.cleanup_files()
+        return
+
+if __name__ == '__main__':
+ RecoverEncryptionKeysTest().main()
+
+

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1727,10 +1727,13 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     if(chainActive.Height() > 1) {
-        LogPrintf("Loading Policy Lists\n");
+        LogPrintf("Loading Policy Lists:\n");
         nStart = GetTimeMillis();
+        LogPrintf("freezelist...\n");
         if (fRequireFreezelistCheck) LoadFreezeList(pcoinsTip);
+        LogPrintf("burnlist...\n");
         if (fEnableBurnlistCheck) LoadBurnList(pcoinsTip);
+        LogPrintf("whitelist.\n");
         if (fRequireWhitelistCheck || fScanWhitelist) {
 	       addressWhitelist->Load(pcoinsTip);
 	    }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -387,6 +387,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), DEFAULT_PERMIT_BAREMULTISIG));
     strUsage += HelpMessageOpt("-pkhwhitelist-encrypt", strprintf(_("Encrypted address whitelisting. (default: %u)"), DEFAULT_WHITELIST_ENCRYPT));
     strUsage += HelpMessageOpt("-pkhwhitelist", strprintf(_("Enable node mempool address whitelisting (default: %u)"), DEFAULT_WHITELIST_CHECK));
+    strUsage += HelpMessageOpt("-recoverwhitelistkeys", strprintf(_("Call the recoverwhitelistkeys RPC on startup (default: %u)"), DEFAULT_RECOVER_WHITELIST_KEYS));
     strUsage += HelpMessageOpt("-pkhwhitelist-scan", strprintf(_("Keep local whitelist updated with own wallet's whitelisted addresses (default: %u)"), DEFAULT_SCAN_WHITELIST));
     strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with bloom filters (default: %u)"), DEFAULT_PEERBLOOMFILTERS));
     strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u)"), defaultChainParams->GetDefaultPort()));
@@ -1122,6 +1123,7 @@ bool AppInitParameterInteraction()
 #endif
     //address whitelisting
     fRequireWhitelistCheck = GetBoolArg("-pkhwhitelist", DEFAULT_WHITELIST_CHECK);
+    fRecoverWhitelistKeys = GetBoolArg("-recoverwhitelistkeys", DEFAULT_RECOVER_WHITELIST_KEYS);
     fScanWhitelist = GetBoolArg("-pkhwhitelist-scan", DEFAULT_SCAN_WHITELIST);
     fWhitelistEncrypt = GetBoolArg("-pkhwhitelist-encrypt", DEFAULT_WHITELIST_ENCRYPT);
     if(fWhitelistEncrypt &! (fRequireWhitelistCheck || fScanWhitelist))
@@ -1130,6 +1132,9 @@ bool AppInitParameterInteraction()
         return InitError("-pkhwhitelist-scan requires -pkhwhitelist-encrypt");
     if(fScanWhitelist && fRequireWhitelistCheck)
         return InitError("cannot enable both -pkhwhitelist and -pkhwhitelist-scan");
+    if(fRecoverWhitelistKeys &! (fRequireWhitelistCheck || fScanWhitelist)){
+        return InitError("frecoverwhitelistkeys requires either -pkhwhitelist or -pkhwhitelist-scan");
+    }
 
     fRequireFreezelistCheck = GetBoolArg("-freezelist", DEFAULT_FREEZELIST_CHECK);
     fEnableBurnlistCheck = GetBoolArg("-burnlist", DEFAULT_BURNLIST_CHECK);

--- a/src/policy/kycfile.cpp
+++ b/src/policy/kycfile.cpp
@@ -99,7 +99,7 @@ bool CKYCFile::read(){
             if(!pwalletMain->GetKey(_onboardPubKey->GetID(), onboardPrivKey))
                 if(!pwalletMain->GetKey(_onboardUserPubKey->GetID(), onboardPrivKey))
                     throw std::invalid_argument(
-                        std::string(std::string(__func__) +  ": cannot get onboard private key"));
+                        std::string(std::string(__func__) +  ": cannot get onboard private key. Use \"syncwhitelistwallet\" to generate more encryption keys."));
 
             std::stringstream ssNBytes;
             ssNBytes << vstr[2];

--- a/src/policy/whitelist.cpp
+++ b/src/policy/whitelist.cpp
@@ -102,13 +102,11 @@ bool CWhiteList::Load(CCoinsView *view)
       pcursor->Next();
     }
 
-    bool fSuccess=true;
-
     if (fRecoverWhitelistKeys){
-      fSuccess = recover_kyc_keys(MAX_KYCPUBKEY_GAP);
+      return recover_kyc_keys(MAX_KYCPUBKEY_GAP);
     }
 
-  return fSuccess;
+  return true;
 }
 
 bool CWhiteList::recover_kyc_keys(uint32_t ngap){

--- a/src/policy/whitelist.h
+++ b/src/policy/whitelist.h
@@ -174,6 +174,7 @@ protected:
 
   	static const CTxDestination _noDest;
 
+  	unsigned int _kycPubKeyTries = 0;
 
 private:
 	void add_unassigned_kyc(const CPubKey& pubKey, const COutPoint& outPoint);

--- a/src/policy/whitelist.h
+++ b/src/policy/whitelist.h
@@ -143,13 +143,11 @@ public:
  	virtual void add_unassigned_kyc(const CPubKey& pubKey){
  		;
  	}
-
-	virtual void get_kycpubkeys(std::set<CPubKey>& keys){
-		keys=_kycUnassignedSet;
-	}
-
   	virtual bool is_unassigned_kyc(const CPubKey& pubKey);
 
+  	bool recover_kyc_keys(uint32_t ngap);
+
+  	bool recover_encryption_key(const CPubKey& pubKey, const uint32_t& maxGen);
 
 protected:
 	std::set<CTxDestination> _myPending;

--- a/src/policy/whitelist.h
+++ b/src/policy/whitelist.h
@@ -144,11 +144,12 @@ public:
  		;
  	}
 
-	void sync_whitelist_wallet(std::vector<CPubKey>& keysNotFound);
+	virtual void get_kycpubkeys(std::set<CPubKey>& keys){
+		keys=_kycUnassignedSet;
+	}
 
-	void sync_whitelist_wallet();
+  	virtual bool is_unassigned_kyc(const CPubKey& pubKey);
 
-	
 
 protected:
 	std::set<CTxDestination> _myPending;
@@ -156,7 +157,6 @@ protected:
 	//KYC pub keys not yet assigned to any user
 	std::set<CPubKey> _kycUnassignedSet;
 	virtual bool remove_unassigned_kyc(const CPubKey& pubKey);
-  	virtual bool is_unassigned_kyc(const CPubKey& pubKey);
 	//Make add_sorted private because we only want verified derived keys 
 	//to be added to the CWhiteList.
 	using CPolicyList::add_sorted;

--- a/src/policy/whitelistEncrypted.cpp
+++ b/src/policy/whitelistEncrypted.cpp
@@ -69,7 +69,7 @@ bool CWhiteListEncrypted::Load(CCoinsView *view)
     }
 
     if(fRecoverWhitelistKeys){
-      recover_kyc_keys(MAX_KYCPUBKEY_GAP);
+      return recover_kyc_keys(MAX_KYCPUBKEY_GAP);
     }
 
   return true;

--- a/src/policy/whitelistEncrypted.cpp
+++ b/src/policy/whitelistEncrypted.cpp
@@ -11,6 +11,7 @@
 #include "policy/policy.h"
 #include "rpc/server.h"
 
+
 CWhiteListEncrypted::CWhiteListEncrypted(){
   _asset=whitelistAsset;
   //The written code behaviour expects nMultisigSize to be of length 1 at the moment. If it is changed in the future the code needs to be adjusted accordingly.
@@ -66,6 +67,11 @@ bool CWhiteListEncrypted::Load(CCoinsView *view)
       }
     pcursor->Next();
     }
+
+    if(fRecoverWhitelistKeys){
+      recover_kyc_keys(MAX_KYCPUBKEY_GAP);
+    }
+
   return true;
 }
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -31,6 +31,7 @@ public:
  */
 static const CRPCConvertParam vRPCConvertParams[] =
 {
+    { "recoverkyckeys", 0, "maxngap"},
     { "recoverencryptionkey", 1, "maxngen"},
     { "onboarduser", 1, "scriptversion"},
     { "topupkycpubkeys", 0, "nkeys" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -31,6 +31,7 @@ public:
  */
 static const CRPCConvertParam vRPCConvertParams[] =
 {
+    { "recoverencryptionkey", 1, "maxngen"},
     { "onboarduser", 1, "scriptversion"},
     { "topupkycpubkeys", 0, "nkeys" },
     { "whitelistkycpubkeys", 0, "kycpubkeys" },

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -87,6 +87,7 @@ bool fRequireStandard = DEFAULT_REQUIRE_STANDARD;
 bool fContractInTx = DEFAULT_CONTRACT_IN_TX;
 bool fContractInKYCFile = DEFAULT_CONTRACT_IN_KYCFILE;
 bool fRequireWhitelistCheck = DEFAULT_WHITELIST_CHECK;
+bool fRecoverWhitelistKeys = DEFAULT_RECOVER_WHITELIST_KEYS;
 bool fScanWhitelist = DEFAULT_SCAN_WHITELIST;
 bool fWhitelistEncrypt = DEFAULT_WHITELIST_ENCRYPT;
 bool fEnableBurnlistCheck = DEFAULT_BURNLIST_CHECK;

--- a/src/validation.h
+++ b/src/validation.h
@@ -137,6 +137,7 @@ static const int64_t MAX_FEE_ESTIMATION_TIP_AGE = 3 * 60 * 60;
 
 static const bool DEFAULT_WHITELIST_ENCRYPT = false;
 static const bool DEFAULT_WHITELIST_CHECK = false;
+static const bool DEFAULT_RECOVER_WHITELIST_KEYS = false;
 static const bool DEFAULT_SCAN_WHITELIST = false;
 static const bool DEFAULT_BLOCK_ISSUANCE = false;
 static const bool DEFAULT_BURNLIST_CHECK = false;
@@ -219,6 +220,7 @@ extern bool fTxIndex;
 extern bool fIsBareMultisigStd;
 extern bool fWhitelistEncrypt;
 extern bool fRequireWhitelistCheck;
+extern bool fRecoverWhitelistKeys;
 extern bool fScanWhitelist;
 extern bool fRequireFreezelistCheck;
 extern bool fRequireRequestListCheck;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1168,6 +1168,48 @@ UniValue removekycpubkey(const JSONRPCRequest& request){
     return RemoveKYCPubKey(kycPubKey);
 }
 
+UniValue recoverkyckeys(const JSONRPCRequest& request){
+    if (!EnsureWalletIsAvailable(request.fHelp))
+        return NullUniValue;
+
+    if (request.fHelp)
+        throw runtime_error(
+            "recoverencryptionkey \"pubkey\" \n"
+            "Generates private keys in the HD encryption key chain until either all the address whitelist KYC keys are found or the number of keys generated between each found key exceed \"maxngap\". The keys are added to the wallet database and keystore.\n"
+            "\nArguments:\n"
+
+            "1. \"maxngap\"   (integer, optional, default=100) The maximum number of new HD encryption keys to generate after each found key (default=100)\n"
+
+            "\nResult:\n"
+            "\"true\" if the keys were all recovered, \"false\" otherwise. All the generated keys are added to the wallet database and keystore"
+
+            "\nExamples:\n"
+            + HelpExampleCli("recoverkyckeys", "100")
+            + HelpExampleRpc("recoverkyckeys", "100")
+            );
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    EnsureWalletIsUnlocked();
+
+    int ngap=100;
+    if(request.params.size() == 1){
+        ngap=request.params[0].get_int();
+    }
+    if(ngap <= 0)
+         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter maxngen: must be greater than 0");
+
+    std::set<CPubKey> kycPubKeys;
+    addressWhitelist->get_kycpubkeys(kycPubKeys);
+
+    for (auto key: kycPubKeys){
+        if(!RecoverEncryptionKey(key, ngap).get_bool())
+            return false;
+    }
+
+    return true;
+}
+
 UniValue recoverencryptionkey(const JSONRPCRequest& request){
     if (!EnsureWalletIsAvailable(request.fHelp))
         return NullUniValue;
@@ -1175,18 +1217,17 @@ UniValue recoverencryptionkey(const JSONRPCRequest& request){
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
         throw runtime_error(
             "recoverencryptionkey \"pubkey\" \n"
+            "Generates keys in the HD encryption key chain until either the private key corresponding to \"pubkey\" is found or \"maxngen\" keys are generated. The keys are added to the wallet database and keystore.\n"
             "\nArguments:\n"
 
             "1. \"pubkey\"    (string, required) The encryption public key (i.e. kyc pub key) to be recovered\n"
-            "2. \"maxngen\"   (integer, optional, default=100) The maximum number of HD encryption keys to generate in searching for the required key (default=100)\n"
+            "2. \"maxngen\"   (integer, optional, default=100) The maximum number of new HD encryption keys to generate (default=100)\n"
             "\nResult:\n"
-            "\"true\" if the key was recovered, \"false\" otherwise. The key is added to the wallet database and keystore"
+            "\"true\" if the key was recovered, \"false\" otherwise. All the generated keys are added to the wallet database and keystore"
             "\nExamples:\n"
             + HelpExampleCli("recoverencryptionkey", "\"pubkey\", 100")
             + HelpExampleRpc("recoverencryptionkey", "\"pubkey\", 100")
             );
-    if(fWhitelistEncrypt)
-        throw JSONRPCError(RPC_MISC_ERROR, "not implemented for encrypted whitelist");
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
@@ -1208,20 +1249,17 @@ UniValue recoverencryptionkey(const JSONRPCRequest& request){
 }
 
 UniValue RecoverEncryptionKey(const CPubKey& pubKey, const uint32_t& maxGen){
-    CKey privKey;
     uint32_t nGen=0;
-    bool bFound=true;
     CKeyID id = pubKey.GetID();
-    while(!pwalletMain->GetKey(id, privKey)){
+    while(!pwalletMain->HaveKey(id)){
       if(nGen >= maxGen){
-        bFound=false;
-        break;
+        return false;
       } else {
         pwalletMain->GenerateNewKey(true);
         ++nGen;
       }
     }
-    return bFound;
+    return true;
 }
 
 UniValue RemoveKYCPubKey(const CPubKey& kycPubKey){
@@ -6113,6 +6151,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "getnunassignedkycpubkeys", &getnunassignedkycpubkeys,  true,   {} },
     { "wallet",             "removekycpubkey",          &removekycpubkey,           false,  {"kycpubkey"} },
     { "wallet",             "recoverencryptionkey",     &recoverencryptionkey,      false,  {"pubkey", "maxngen"} },
+    { "wallet",             "recoverkyckeys",           &recoverkyckeys,            false,  {"maxngap"} },
     { "wallet",             "blacklistkycpubkey",       &blacklistkycpubkey,        false,  {"kycpubkey"} },
     { "wallet",             "whitelistkycpubkeys",      &whitelistkycpubkeys,       false,  {"kycpubkeys"} },
     { "wallet",             "validatederivedkeys",      &validatederivedkeys,       true,   {"filename"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1199,15 +1199,9 @@ UniValue recoverkyckeys(const JSONRPCRequest& request){
     if(ngap <= 0)
          throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter maxngen: must be greater than 0");
 
-    std::set<CPubKey> kycPubKeys;
-    addressWhitelist->get_kycpubkeys(kycPubKeys);
 
-    for (auto key: kycPubKeys){
-        if(!RecoverEncryptionKey(key, ngap).get_bool())
-            return false;
-    }
+    return addressWhitelist->recover_kyc_keys(ngap);
 
-    return true;
 }
 
 UniValue recoverencryptionkey(const JSONRPCRequest& request){
@@ -1245,21 +1239,7 @@ UniValue recoverencryptionkey(const JSONRPCRequest& request){
     if(ngen <= 0)
          throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter maxngen: must be greater than 0");
 
-    return RecoverEncryptionKey(pubKey, ngen);
-}
-
-UniValue RecoverEncryptionKey(const CPubKey& pubKey, const uint32_t& maxGen){
-    uint32_t nGen=0;
-    CKeyID id = pubKey.GetID();
-    while(!pwalletMain->HaveKey(id)){
-      if(nGen >= maxGen){
-        return false;
-      } else {
-        pwalletMain->GenerateNewKey(true);
-        ++nGen;
-      }
-    }
-    return true;
+    return addressWhitelist->recover_encryption_key(pubKey, ngen);
 }
 
 UniValue RemoveKYCPubKey(const CPubKey& kycPubKey){

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -13,6 +13,4 @@ void RegisterWalletRPCCommands(CRPCTable &t);
 
 UniValue RemoveKYCPubKey(const CPubKey& kycPubKey);
 
-UniValue RecoverEncryptionKey(const CPubKey& pubKey, const uint32_t& maxGen);
-
 #endif //BITCOIN_WALLET_RPCWALLET_H

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -13,4 +13,6 @@ void RegisterWalletRPCCommands(CRPCTable &t);
 
 UniValue RemoveKYCPubKey(const CPubKey& kycPubKey);
 
+UniValue RecoverEncryptionKey(const CPubKey& pubKey, const uint32_t& maxGen);
+
 #endif //BITCOIN_WALLET_RPCWALLET_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1480,6 +1480,11 @@ bool CWallet::IsHDEnabled()
     return !hdChain.masterKeyID.IsNull();
 }
 
+bool CWallet::IsEncryptionHDEnabled()
+{
+    return !hdEncryptionChain.masterKeyID.IsNull();
+}
+
 int64_t CWalletTx::GetTxTime() const
 {
     int64_t n = nTimeSmart;
@@ -4011,6 +4016,14 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
     if (nLoadWalletRet != DB_LOAD_OK)
         return nLoadWalletRet;
     fFirstRunRet = !vchDefaultKey.IsValid();
+
+    // If the HD chain is set but the encryption HD chain is not, initialize the 
+    // encryption chain to the same seed
+    if (IsHDEnabled() && !IsEncryptionHDEnabled()){
+            CHDChain newHdEncryptionChain;
+            newHdEncryptionChain.masterKeyID = hdChain.masterKeyID;
+            SetHDEncryptionChain(newHdEncryptionChain, false);
+    }
 
     uiInterface.LoadWallet(this);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4013,10 +4013,6 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
         }
     }
 
-    if (nLoadWalletRet != DB_LOAD_OK)
-        return nLoadWalletRet;
-    fFirstRunRet = !vchDefaultKey.IsValid();
-
     // If the HD chain is set but the encryption HD chain is not, initialize the 
     // encryption chain to the same seed
     if (IsHDEnabled() && !IsEncryptionHDEnabled()){
@@ -4024,6 +4020,10 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
             newHdEncryptionChain.masterKeyID = hdChain.masterKeyID;
             SetHDEncryptionChain(newHdEncryptionChain, false);
     }
+
+    if (nLoadWalletRet != DB_LOAD_OK)
+        return nLoadWalletRet;
+    fFirstRunRet = !vchDefaultKey.IsValid();
 
     uiInterface.LoadWallet(this);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3987,9 +3987,6 @@ CAmount CWallet::GetMinimumFee(unsigned int nTxBytes, unsigned int nConfirmTarge
     return nFeeNeeded;
 }
 
-
-
-
 DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
 {
     if (!fFileBacked)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -146,14 +146,14 @@ CPubKey CWallet::GenerateNewKey(bool bEncryption)
 
 
 void CWallet::DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret, CHDChain& chain,
-    const char* chainName,  const uint32_t& iExternal){
+    const std::string& chainName,  const uint32_t& iExternal){
 
     // for now we use a fixed keypath scheme of m/0'/0'/k
     CKey key;                      //master key seed (256bit)
     CExtKey masterKey;             //hd master key
     CExtKey accountKey;            //key at m/0'
-    CExtKey externalChainChildKey; //key at m/0'/iEncryption'
-    CExtKey childKey;              //key at m/0'/iEncryption'/<n>'
+    CExtKey externalChainChildKey; //key at m/0'/iExternal'
+    CExtKey childKey;              //key at m/0'/iExternal'/<n>'
 
     // try to get the master key
     if (!GetKey(chain.masterKeyID, key))
@@ -192,12 +192,12 @@ void CWallet::DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret, CHDChain& 
 
 void CWallet::DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret)
 {
-    DeriveNewChildKey(metadata, secret, hdChain, "hdchain", 0);
+    DeriveNewChildKey(metadata, secret, hdChain, std::string("hdchain"), 0);
 }
 
 void CWallet::DeriveNewEncryptionChildKey(CKeyMetadata& metadata, CKey& secret)
 {
-    DeriveNewChildKey(metadata, secret, hdEncryptionChain, "encryptionhdchain", 2);
+    DeriveNewChildKey(metadata, secret, hdEncryptionChain, std::string("encryptionhdchain"), 2);
 }
 
 bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -156,7 +156,7 @@ void CWallet::DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret, CHDChain& 
     CExtKey childKey;              //key at m/0'/iEncryption'/<n>'
 
     // try to get the master key
-    if (!GetKey(hdEncryptionChain.masterKeyID, key))
+    if (!GetKey(chain.masterKeyID, key))
         throw std::runtime_error(std::string(__func__) + ": Master key not found");
 
     masterKey.SetMaster(key.begin(), key.size());
@@ -175,12 +175,12 @@ void CWallet::DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret, CHDChain& 
         // always derive hardened keys
         // childIndex | BIP32_HARDENED_KEY_LIMIT = derive childIndex in hardened child-index-range
         // example: 1 | BIP32_HARDENED_KEY_LIMIT == 0x80000001 == 2147483649
-        externalChainChildKey.Derive(childKey, hdEncryptionChain.nExternalChainCounter | BIP32_HARDENED_KEY_LIMIT);
+        externalChainChildKey.Derive(childKey, chain.nExternalChainCounter | BIP32_HARDENED_KEY_LIMIT);
         metadata.hdKeypath = "m/0'/" + std::to_string(iExternal) + "'/" + 
-            std::to_string(hdEncryptionChain.nExternalChainCounter) + "'";
-        metadata.hdMasterKeyID = hdEncryptionChain.masterKeyID;
+            std::to_string(chain.nExternalChainCounter) + "'";
+        metadata.hdMasterKeyID = chain.masterKeyID;
         // increment childkey index
-        hdEncryptionChain.nExternalChainCounter++;
+        chain.nExternalChainCounter++;
     } while (HaveKey(childKey.key.GetPubKey().GetID()));
     secret = childKey.key;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -227,7 +227,7 @@ void CWallet::DeriveNewEncryptionChildKey(CKeyMetadata& metadata, CKey& secret)
     secret = childKey.key;
 
     // update the chain model in the database
-    if (!CWalletDB(strWalletFile).WriteHDChain(hdEncryptionChain))
+    if (!CWalletDB(strWalletFile).WriteHDEncryptionChain(hdEncryptionChain))
         throw std::runtime_error(std::string(__func__) + ": Writing HD encryption chain model failed");
 }
 
@@ -1447,7 +1447,10 @@ bool CWallet::SetHDMasterKey(const CPubKey& pubkey)
     CHDChain newHdChain;
     newHdChain.masterKeyID = pubkey.GetID();
     SetHDChain(newHdChain, false);
-    SetHDEncryptionChain(newHdChain, false);
+ 
+    CHDChain newHdEncryptionChain;
+    newHdEncryptionChain.masterKeyID = pubkey.GetID();
+    SetHDEncryptionChain(newHdEncryptionChain, false);
 
     return true;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1104,6 +1104,10 @@ public:
     /* Returns true if HD is enabled */
     bool IsHDEnabled();
 
+    /* Returns true if the Encryption HD chain is enabled */
+    bool IsEncryptionHDEnabled();
+
+
     /* Generates a new HD master key (will not be activated) */
     CPubKey GenerateNewHDMasterKey();
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -660,6 +660,8 @@ private:
 
     /* the HD chain data model (external chain counters) */
     CHDChain hdChain;
+    /* the HD chain data model for the encrryption key chain (external chain counters) */
+    CHDChain hdEncryptionChain;
 
     bool fFileBacked;
 
@@ -806,11 +808,9 @@ public:
      * Generate a new key
      */
     CPubKey GenerateNewKey(const bool bEncryption=false);
-    void DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret, const unsigned int nExternalChain=0);
-    void DeriveNewEncryptionChildKey(CKeyMetadata& metadata, CKey& secret){
-        //Using externalChangeChildKey path = 2' for encryption keys.
-        DeriveNewChildKey(metadata, secret, 2);
-    }
+    void DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret);
+    void DeriveNewEncryptionChildKey(CKeyMetadata& metadata, CKey& secret);
+
     //! Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
@@ -1096,6 +1096,10 @@ public:
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(const CHDChain& chain, bool memonly);
     const CHDChain& GetHDChain() { return hdChain; }
+
+    /* Set the HD encryption chain model (chain child index counters) */
+    bool SetHDEncryptionChain(const CHDChain& chain, bool memonly);
+    const CHDChain& GetHDEncryptionChain() { return hdEncryptionChain; }
 
     /* Returns true if HD is enabled */
     bool IsHDEnabled();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -810,6 +810,8 @@ public:
     CPubKey GenerateNewKey(const bool bEncryption=false);
     void DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret);
     void DeriveNewEncryptionChildKey(CKeyMetadata& metadata, CKey& secret);
+    void DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret, CHDChain& chain,
+    const char* chainName,  const uint32_t& iExternal);
 
     //! Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -811,7 +811,7 @@ public:
     void DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret);
     void DeriveNewEncryptionChildKey(CKeyMetadata& metadata, CKey& secret);
     void DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret, CHDChain& chain,
-    const char* chainName,  const uint32_t& iExternal);
+    const std::string& chainName,  const uint32_t& iExternal);
 
     //! Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -994,7 +994,7 @@ bool CWalletDB::EraseDestData(const std::string &address, const std::string &key
     return Erase(std::make_pair(std::string("destdata"), std::make_pair(address, key)));
 }
 
-bool CWalletDB::WriteHDChain(const CHDChain& chain, std::string chainName)
+bool CWalletDB::WriteHDChain(const CHDChain& chain, const std::string& chainName)
 {
     nWalletDBUpdateCounter++;
     return Write(chainName, chain);
@@ -1002,14 +1002,12 @@ bool CWalletDB::WriteHDChain(const CHDChain& chain, std::string chainName)
 
 bool CWalletDB::WriteHDChain(const CHDChain& chain)
 {
-    nWalletDBUpdateCounter++;
-    return Write(std::string("hdchain"), chain);
+    return WriteHDChain(chain, std::string("hdchain"));
 }
 
 bool CWalletDB::WriteHDEncryptionChain(const CHDChain& chain)
 {
-    nWalletDBUpdateCounter++;
-    return Write(std::string("encryptionhdchain"), chain);
+    return WriteHDChain(chain, std::string("encryptionhdchain"));
 }
 
 void CWalletDB::IncrementUpdateCounter()

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -549,6 +549,16 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 return false;
             }
         }
+        else if (strType == "encryptionhdchain")
+        {
+            CHDChain chain;
+            ssValue >> chain;
+            if (!pwallet->SetHDEncryptionChain(chain, true))
+            {
+                strErr = "Error reading wallet database: SetEncryptioonHDChain failed";
+                return false;
+            }
+        }
         else if (strType == "blindingderivationkey")
         {
             assert(pwallet->blinding_derivation_key.IsNull());
@@ -947,7 +957,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKe
                 fReadOK = ReadKeyValue(&dummyWallet, ssKey, ssValue,
                                         wss, strType, strErr);
             }
-            if (!IsKeyType(strType) && strType != "hdchain")
+            if (!IsKeyType(strType) && strType != "hdchain" && strType != "encryptionhdchain")
                 continue;
             if (!fReadOK)
             {
@@ -989,6 +999,12 @@ bool CWalletDB::WriteHDChain(const CHDChain& chain)
 {
     nWalletDBUpdateCounter++;
     return Write(std::string("hdchain"), chain);
+}
+
+bool CWalletDB::WriteHDEncryptionChain(const CHDChain& chain)
+{
+    nWalletDBUpdateCounter++;
+    return Write(std::string("encryptionhdchain"), chain);
 }
 
 void CWalletDB::IncrementUpdateCounter()

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -555,7 +555,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssValue >> chain;
             if (!pwallet->SetHDEncryptionChain(chain, true))
             {
-                strErr = "Error reading wallet database: SetEncryptioonHDChain failed";
+                strErr = "Error reading wallet database: SetEncryptionHDChain failed";
                 return false;
             }
         }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -994,6 +994,11 @@ bool CWalletDB::EraseDestData(const std::string &address, const std::string &key
     return Erase(std::make_pair(std::string("destdata"), std::make_pair(address, key)));
 }
 
+bool CWalletDB::WriteHDChain(const CHDChain& chain, std::string chainName)
+{
+    nWalletDBUpdateCounter++;
+    return Write(chainName, chain);
+}
 
 bool CWalletDB::WriteHDChain(const CHDChain& chain)
 {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -186,6 +186,9 @@ public:
     //! write the hdencryptionchain model (external chain child index counter)
     bool WriteHDEncryptionChain(const CHDChain& chain);
 
+    //! write the HD chain model with the given name 
+    bool WriteHDChain(const CHDChain& chain, std::string chainName);
+
     static void IncrementUpdateCounter();
     static unsigned int GetUpdateCounter();
 private:

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -187,7 +187,7 @@ public:
     bool WriteHDEncryptionChain(const CHDChain& chain);
 
     //! write the HD chain model with the given name 
-    bool WriteHDChain(const CHDChain& chain, std::string chainName);
+    bool WriteHDChain(const CHDChain& chain, const std::string& chainName);
 
     static void IncrementUpdateCounter();
     static unsigned int GetUpdateCounter();

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -183,6 +183,9 @@ public:
     //! write the hdchain model (external chain child index counter)
     bool WriteHDChain(const CHDChain& chain);
 
+    //! write the hdencryptionchain model (external chain child index counter)
+    bool WriteHDEncryptionChain(const CHDChain& chain);
+
     static void IncrementUpdateCounter();
     static unsigned int GetUpdateCounter();
 private:


### PR DESCRIPTION
- RPCs for recovery of encryption keys: recoverencryptionkey and recoverkyckeys. These can be used to generate the encryption keys when the wallet is loaded from an earlier state or restored from seed.
- Do not automatically try and recover encryption keys for every wallet (sync_whitelist_wallet removed from whitelist.cpp). The above RPCs can be used instead, if needed.
- Store the encryption keys HD chain independently. Seperate child counters for main and encryption HD wallet paths.