### PR TITLE
Getsidechaininfo type fix

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -33,8 +33,6 @@
 #include <boost/thread/thread.hpp> // boost::thread::interrupt
 #include <boost/algorithm/string.hpp>
 
-#include <typeinfo>
-
 #include <mutex>
 #include <condition_variable>
 using namespace std;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -33,6 +33,7 @@
 #include <boost/thread/thread.hpp> // boost::thread::interrupt
 #include <boost/algorithm/string.hpp>
 
+#include <typeinfo>
 
 #include <mutex>
 #include <condition_variable>
@@ -1569,10 +1570,10 @@ UniValue getsidechaininfo(const JSONRPCRequest& request)
     obj.push_back(Pair("parent_blockhash", parent_blockhash.GetHex()));
 
     UniValue AddrPrefixes(UniValue::VOBJ);
-    AddrPrefixes.push_back(Pair("PUBKEY_ADDRESS", CChainParams::PUBKEY_ADDRESS));
-    AddrPrefixes.push_back(Pair("BLINDED_ADDRESS", CChainParams::BLINDED_ADDRESS));
-    AddrPrefixes.push_back(Pair("SECRET_KEY", CChainParams::SECRET_KEY));
-    AddrPrefixes.push_back(Pair("SCRIPT_ADDRESS", CChainParams::SCRIPT_ADDRESS));
+    AddrPrefixes.push_back(Pair("PUBKEY_ADDRESS",Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS)[0]));
+    AddrPrefixes.push_back(Pair("BLINDED_ADDRESS", Params().Base58Prefix(CChainParams::BLINDED_ADDRESS)[0]));
+    AddrPrefixes.push_back(Pair("SECRET_KEY", Params().Base58Prefix(CChainParams::SECRET_KEY)[0]));
+    AddrPrefixes.push_back(Pair("SCRIPT_ADDRESS", Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS)[0]));
 
     obj.push_back(Pair("addr_prefixes", AddrPrefixes));
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -131,7 +131,7 @@ const unordered_set<string> availableArgs = {
 "-choosedatadir","-lang","-min","-rootcertificates","-splash","-resetguisettings","-uiplatform","-rpcssl","-benchmark","-socks","-debugnet","-walletprematurewitness","-prematurewitness","-promiscuousmempoolflags","-con_fpowallowmindifficultyblocks",
 "-con_fpownoretargeting","-con_nsubsidyhalvinginterval","-con_bip34height","-con_bip65height","-con_bip66height","-con_npowtargettimespan","-con_npowtargetspacing","-con_nrulechangeactivationthreshold","-con_nminerconfirmationwindow","-con_powlimit",
 "-con_parentpowlimit","-con_bip34hash","-con_nminimumchainwork","-con_defaultassumevalid","-parentgenesisblockhash","-ndefaultport","-npruneafterheight","-fdefaultconsistencychecks","-frequirestandard","-fmineblocksondemand","-ct_bits","-ct_exponent",
-"-anyonecanspendaremine","-fminingrequirespeers","-con_mandatorycoinbase","-recoverenccryptionkeys"}; // last items included for tests
+"-anyonecanspendaremine","-fminingrequirespeers","-con_mandatorycoinbase","-recoverwhitelistkeys"}; // last items included for tests
 bool fDebug = false;
 bool fPrintToConsole = false;
 bool fPrintToAll = false;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -131,7 +131,7 @@ const unordered_set<string> availableArgs = {
 "-choosedatadir","-lang","-min","-rootcertificates","-splash","-resetguisettings","-uiplatform","-rpcssl","-benchmark","-socks","-debugnet","-walletprematurewitness","-prematurewitness","-promiscuousmempoolflags","-con_fpowallowmindifficultyblocks",
 "-con_fpownoretargeting","-con_nsubsidyhalvinginterval","-con_bip34height","-con_bip65height","-con_bip66height","-con_npowtargettimespan","-con_npowtargetspacing","-con_nrulechangeactivationthreshold","-con_nminerconfirmationwindow","-con_powlimit",
 "-con_parentpowlimit","-con_bip34hash","-con_nminimumchainwork","-con_defaultassumevalid","-parentgenesisblockhash","-ndefaultport","-npruneafterheight","-fdefaultconsistencychecks","-frequirestandard","-fmineblocksondemand","-ct_bits","-ct_exponent",
-"-anyonecanspendaremine","-fminingrequirespeers","-con_mandatorycoinbase"}; // last items included for tests
+"-anyonecanspendaremine","-fminingrequirespeers","-con_mandatorycoinbase","-recoverenccryptionkeys"}; // last items included for tests
 bool fDebug = false;
 bool fPrintToConsole = false;
 bool fPrintToAll = false;


### PR DESCRIPTION
``getsidechaininfo`` RPC was incorrectly returning address prefixes. Now returns as ints.