### PR TITLE
Min depth for usable whitelist asset = 1

### DIFF
--- a/qa/rpc-tests/onboard_cit.py
+++ b/qa/rpc-tests/onboard_cit.py
@@ -188,7 +188,7 @@ class OnboardTest (BitcoinTestFramework):
         #Register a KYC public key
         nkyckeys=50
         self.nodes[0].topupkycpubkeys(nkyckeys)
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         self.nodes[0].dumpkycpubkeys(kycpkfile)
@@ -198,7 +198,7 @@ class OnboardTest (BitcoinTestFramework):
         #Register more keys (top up to 100)
         nkyckeys=100
         self.nodes[0].topupkycpubkeys(nkyckeys)
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         self.nodes[0].dumpkycpubkeys(kycpkfile)
@@ -218,7 +218,7 @@ class OnboardTest (BitcoinTestFramework):
                         assert(False)
 
         time.sleep(5)
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         self.nodes[0].dumpkycpubkeys(kycpkfile)
@@ -227,7 +227,7 @@ class OnboardTest (BitcoinTestFramework):
 
         #Register a KYC public key
         self.nodes[0].topupkycpubkeys(1)
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         self.nodes[0].dumpkycpubkeys(kycpkfile)
@@ -260,7 +260,7 @@ class OnboardTest (BitcoinTestFramework):
         #Old registeraddresss script (version 0)
         self.nodes[0].onboarduser(kycfile0, 0)
         print("generate block \n")
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         print("sync all \n")
         self.sync_all()
 
@@ -276,12 +276,12 @@ class OnboardTest (BitcoinTestFramework):
         kycfile_plain=self.initfile(os.path.join(self.options.tmpdir,"kycfile_plain.dat"))
         self.nodes[0].readkycfile(kycfile, kycfile_plain)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         balance_1=self.nodes[0].getwalletinfo()["balance"]["WHITELIST"]
         self.nodes[0].onboarduser(kycfile)
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         with open(kycfile_plain) as fp:
@@ -338,7 +338,7 @@ class OnboardTest (BitcoinTestFramework):
         #Send some tokens to node 1
         ntosend=10.234
         self.nodes[0].sendtoaddress(node1addr, ntosend, "", "", False, "CBT")
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
 
@@ -402,7 +402,7 @@ class OnboardTest (BitcoinTestFramework):
             assert("Not implemented for unencrypted whitelist" in e.error['message'])
 
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
         wl1file_2=self.initfile(os.path.join(self.options.tmpdir,"wl1_2.dat"))
         self.nodes[1].dumpwhitelist(wl1file_2)
@@ -430,7 +430,7 @@ class OnboardTest (BitcoinTestFramework):
         assert(vaddr['ismine'])
 
         issue = self.nodes[0].issueasset('100.0','0')
-        self.nodes[1].generate(6)
+        self.nodes[1].generate(1)
         self.sync_all()
 
         multiAddress1=self.nodes[1].createmultisig(2,[clientAddress1['pubkey'],clientAddress2['pubkey'],clientAddress3['pubkey']])
@@ -523,7 +523,7 @@ class OnboardTest (BitcoinTestFramework):
 
         # issue some new asset (that is not the domain asset)
         issue = self.nodes[0].issueasset('100.0','0')
-        self.nodes[1].generate(6)
+        self.nodes[1].generate(1)
 
         nonPolicyAddress1=self.nodes[1].validateaddress(self.nodes[1].getnewaddress())
         nonPolicyAddress2=self.nodes[1].validateaddress(self.nodes[1].getnewaddress())
@@ -542,7 +542,7 @@ class OnboardTest (BitcoinTestFramework):
 
         # Send 12 issued asset from 0 to 1 using sendtoaddress. Will fail to create mempool transaction because recipient addresses not whitelisted.
         txidm = self.nodes[0].sendtoaddress(multiAddr['address'], 12,"","",False,issue["asset"])
-        self.nodes[1].generate(6)
+        self.nodes[1].generate(1)
         self.sync_all()
 
         try:
@@ -572,7 +572,7 @@ class OnboardTest (BitcoinTestFramework):
         nlines4=self.linecount(wl1file_4)
 
         self.nodes[0].blacklistuser(kycfile)
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         wl1_bl_file=self.initfile(os.path.join(self.options.tmpdir,"wl1_bl.dat"))
@@ -590,7 +590,7 @@ class OnboardTest (BitcoinTestFramework):
         #Re-whitelist node1 wallet
         self.nodes[0].onboarduser(kycfile)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         wl1file_rwl=self.initfile(os.path.join(self.options.tmpdir,"wl1_rwl.dat"))

--- a/qa/rpc-tests/onboard_cit.py
+++ b/qa/rpc-tests/onboard_cit.py
@@ -572,7 +572,7 @@ class OnboardTest (BitcoinTestFramework):
         nlines4=self.linecount(wl1file_4)
 
         self.nodes[0].blacklistuser(kycfile)
-        self.nodes[0].generate(1)
+        self.nodes[0].generate(6)
         self.sync_all()
 
         wl1_bl_file=self.initfile(os.path.join(self.options.tmpdir,"wl1_bl.dat"))
@@ -590,7 +590,7 @@ class OnboardTest (BitcoinTestFramework):
         #Re-whitelist node1 wallet
         self.nodes[0].onboarduser(kycfile)
 
-        self.nodes[0].generate(1)
+        self.nodes[0].generate(6)
         self.sync_all()
 
         wl1file_rwl=self.initfile(os.path.join(self.options.tmpdir,"wl1_rwl.dat"))

--- a/qa/rpc-tests/onboardmanual_cit.py
+++ b/qa/rpc-tests/onboardmanual_cit.py
@@ -214,7 +214,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
         assert(wltx_signed["complete"])
         wltx_send = self.nodes[0].sendrawtransaction(wltx_signed["hex"])
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         assert_equal(self.nodes[0].getnunassignedkycpubkeys(), 1)
@@ -274,7 +274,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_p2sh)
@@ -291,7 +291,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_p2sh)
@@ -304,7 +304,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_p2sh)
@@ -331,7 +331,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_p2pkh)
@@ -348,7 +348,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_p2pkh)
@@ -361,7 +361,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_p2pkh)
@@ -406,7 +406,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
         assert(valkyc["iswhitelisted"] == False)
         assert(len(valkyc["addresses"]) == 2)
         
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
 
@@ -434,7 +434,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_normal)
@@ -447,7 +447,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_normal)
@@ -460,7 +460,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_normal)
@@ -482,7 +482,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
         assert(valkyc["iswhitelisted"] == False)
         assert(len(valkyc["addresses"]) == 1)
         
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         #Test invalid parameters
@@ -501,7 +501,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_p2sh)
@@ -532,7 +532,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_multisig)
@@ -545,7 +545,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_multisig)
@@ -558,7 +558,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile_multisig)
@@ -685,7 +685,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
         
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile)
@@ -699,7 +699,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile)
@@ -712,7 +712,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             print(e.error['message'])
             assert(False)
 
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         valkyc=self.nodes[0].validatekycfile(kycfile)
@@ -793,7 +793,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
         assert(valkyc["iswhitelisted"] == False)
         assert(len(valkyc["addresses"]) == nAddresses)
         
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         try:
@@ -816,7 +816,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
         assert(valkyc["iswhitelisted"] == False)
         assert(len(valkyc["addresses"]) == nAddresses)
         
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         try:
@@ -826,7 +826,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
             assert(False)
 
             
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         #Check that the TX size > MAX_SCRIPT_SIZE
@@ -853,7 +853,7 @@ class OnboardManualCITTest (BitcoinTestFramework):
 
         #Add some more kycpubkeys
         self.nodes[0].topupkycpubkeys(100)
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(1)
         self.sync_all()
 
         assert_equal(self.nodes[0].getnunassignedkycpubkeys(),100)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -131,7 +131,7 @@ const unordered_set<string> availableArgs = {
 "-choosedatadir","-lang","-min","-rootcertificates","-splash","-resetguisettings","-uiplatform","-rpcssl","-benchmark","-socks","-debugnet","-walletprematurewitness","-prematurewitness","-promiscuousmempoolflags","-con_fpowallowmindifficultyblocks",
 "-con_fpownoretargeting","-con_nsubsidyhalvinginterval","-con_bip34height","-con_bip65height","-con_bip66height","-con_npowtargettimespan","-con_npowtargetspacing","-con_nrulechangeactivationthreshold","-con_nminerconfirmationwindow","-con_powlimit",
 "-con_parentpowlimit","-con_bip34hash","-con_nminimumchainwork","-con_defaultassumevalid","-parentgenesisblockhash","-ndefaultport","-npruneafterheight","-fdefaultconsistencychecks","-frequirestandard","-fmineblocksondemand","-ct_bits","-ct_exponent",
-"-anyonecanspendaremine","-fminingrequirespeers","-con_mandatorycoinbase"}; // last items included for tests
+"-anyonecanspendaremine","-fminingrequirespeers","-con_mandatorycoinbase", "-recoverencryptionkeys"}
 bool fDebug = false;
 bool fPrintToConsole = false;
 bool fPrintToAll = false;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -131,7 +131,7 @@ const unordered_set<string> availableArgs = {
 "-choosedatadir","-lang","-min","-rootcertificates","-splash","-resetguisettings","-uiplatform","-rpcssl","-benchmark","-socks","-debugnet","-walletprematurewitness","-prematurewitness","-promiscuousmempoolflags","-con_fpowallowmindifficultyblocks",
 "-con_fpownoretargeting","-con_nsubsidyhalvinginterval","-con_bip34height","-con_bip65height","-con_bip66height","-con_npowtargettimespan","-con_npowtargetspacing","-con_nrulechangeactivationthreshold","-con_nminerconfirmationwindow","-con_powlimit",
 "-con_parentpowlimit","-con_bip34hash","-con_nminimumchainwork","-con_defaultassumevalid","-parentgenesisblockhash","-ndefaultport","-npruneafterheight","-fdefaultconsistencychecks","-frequirestandard","-fmineblocksondemand","-ct_bits","-ct_exponent",
-"-anyonecanspendaremine","-fminingrequirespeers","-con_mandatorycoinbase", "-recoverencryptionkeys"}
+"-anyonecanspendaremine","-fminingrequirespeers","-con_mandatorycoinbase", "-recoverencryptionkeys"};
 bool fDebug = false;
 bool fPrintToConsole = false;
 bool fPrintToAll = false;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -768,7 +768,7 @@ static void SendOnboardTx(const CScript& script,  CWalletTx& wtxNew){
     coinControl->nFeeRate=CFeeRate(0);
     coinControl->fAllowOtherInputs=false;
 
-    int nMinDepth=6;
+    int nMinDepth=1;
     int nMaxDepth=9999999;
 
     vector<COutput> vecOutputs;


### PR DESCRIPTION
When generating whitelisting transaction, the min number of confirmations to spend outputs is set to 1