### PR TITLE
add metadata to sendany

### DIFF
--- a/qa/rpc-tests/sendany.py
+++ b/qa/rpc-tests/sendany.py
@@ -183,5 +183,18 @@ class SendAnyTest (BitcoinTestFramework):
         self.nodes[3].generate(1)
         self.sync_all()
 
+        # test sendanytoaddress metadata tag
+        metadata = 'ec45a16ce1a3eb5784df3dfa196aad6bd57f6c2f6969e97d1eb5402ccd39d627'
+        txid = self.nodes[0].sendanytoaddress(addr1, 0.5, "", "", True, False,1,metadata)
+        assert(txid in self.nodes[0].getrawmempool())
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        tx = self.nodes[0].getrawtransaction(txid,True)
+        or_md = False
+        for outpt in tx["vout"]:
+            if outpt["scriptPubKey"]["hex"] == '6a20' + metadata: or_md = True
+        assert(or_md)
+
 if __name__ == '__main__':
     SendAnyTest().main()

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -591,7 +591,7 @@ static vector<CWalletTx> SendMoney(const CTxDestination &address, CAmount nValue
 }
 
 static vector<CWalletTx> SendAnyMoney(const CScript& scriptPubKey, CAmount nValue, const CPubKey &confidentiality_key,
-    CWalletTx& wtxNew, bool fIgnoreBlindFail, bool fSplitTransactions = false, int nSortingMethod = 1,
+    CWalletTx& wtxNew, bool fIgnoreBlindFail, bool fSplitTransactions = false, int nSortingMethod = 1, std::string metadataStr = "",
     CCoinControl* coinControl = NULL, bool fSign = true, bool fSend = true)
 {
     // Check amount
@@ -670,9 +670,10 @@ static vector<CWalletTx> SendAnyMoney(const CScript& scriptPubKey, CAmount nValu
     }
     vChangeKeys.push_back(vChangeKey);
 
+    std::map<CAsset, std::vector<COutput>>* mAvailableInputs = nullptr;
     std::vector<CWalletTx> vecRes = pwalletMain->CreateTransaction(vecSend, wtxNew, vChangeKeys, nFeeRequired,
         nChangePosRet, strError, coinControl, fSign, NULL, true, NULL, NULL, NULL, CAsset(), fIgnoreBlindFail,
-        fSplitTransactions, std::vector<COutput>(), true);
+        fSplitTransactions, std::vector<COutput>(), true, mAvailableInputs, metadataStr);
     if (!(vecRes.size() > 0)) {
         if (nValue + nFeeRequired > totalBalance)
             strError = strprintf("Error: This transaction requires a transaction fee of at least %s",
@@ -694,11 +695,11 @@ static vector<CWalletTx> SendAnyMoney(const CScript& scriptPubKey, CAmount nValu
 }
 
 static vector<CWalletTx> SendAnyMoney(const CTxDestination &address, CAmount nValue, const CPubKey &confidentiality_key,
-    CWalletTx& wtxNew, bool fIgnoreBlindFail, bool fSplitTransactions, int nSortingMethod,
+    CWalletTx& wtxNew, bool fIgnoreBlindFail, bool fSplitTransactions, int nSortingMethod, std::string metadataStr,
     CCoinControl* coinControl = NULL, bool fSign = true, bool fSend = true)
 {
     return SendAnyMoney(GetScriptForDestination(address), nValue, confidentiality_key, wtxNew, fIgnoreBlindFail,
-        fSplitTransactions, nSortingMethod, coinControl, fSign, fSend);
+        fSplitTransactions, nSortingMethod, metadataStr, coinControl, fSign, fSend);
 }
 
 static void SendGenerationTransaction(const CScript& assetScriptPubKey, const CPubKey &assetKey, const CScript& tokenScriptPubKey, const CPubKey &tokenKey, CAmount nAmountAsset, CAmount nTokens, bool fBlindIssuances, uint256& entropy, CAsset& reissuanceAsset, CAsset& reissuanceToken, CWalletTx& wtxNew)
@@ -1870,8 +1871,9 @@ UniValue createanytoaddress(const JSONRPCRequest& request)
     //coinControl.nFeeRate = specificFeeRate;
 
     CWalletTx wtx;
+    std::string metadataStr;
     vector<CWalletTx> wtxs = SendAnyMoney(address.Get(), nAmount, confidentiality_pubkey,
-        wtx, fIgnoreBlindFail, fSplitTransactions, fSortingType, &coinControl, false, false);
+        wtx, fIgnoreBlindFail, fSplitTransactions, fSortingType, metadataStr, &coinControl, false, false);
 
     UniValue arr(UniValue::VARR);
     for (const auto &tx: wtxs) {
@@ -1885,7 +1887,7 @@ UniValue sendanytoaddress(const JSONRPCRequest& request)
     if (!EnsureWalletIsAvailable(request.fHelp))
         return NullUniValue;
 
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 7)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 8)
         throw runtime_error(
             "sendanytoaddress \"bitcoinaddress\" amount ( \"comment\" \"comment-to\" ignoreblindfail splitlargetxs balanceSortType)\n"
             "\nSend an amount to a given address with as many non-policy assets as needed.\n"
@@ -1902,6 +1904,7 @@ UniValue sendanytoaddress(const JSONRPCRequest& request)
             "5. \"ignoreblindfail\"\"   (bool, default=true) Return a transaction even when a blinding attempt fails due to number of blinded inputs/outputs.\n"
             "6. \"splitlargetxs\"\"   (bool, default=false) Split a transaction that goes over the size limit into smaller transactions.\n"
             "7. \"balanceSortType\"\"   (numeric, default=1) Choose which balances should be used first. 1 - descending, 2 - ascending\n"
+            "8. \"metadata\"\"   (string, optional) Add an OP_RETURN output for transaction metadata\n"
             "\nResult:\n"
             "\"txid\"                  (string) The transaction id.\n"
             "\nExamples:\n"
@@ -1952,11 +1955,19 @@ UniValue sendanytoaddress(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid sendany sorting type.");
     }
 
+    string metadataStr;
+    if (request.params.size() > 7) {
+        metadataStr = request.params[7].get_str();
+        if (!IsHex(metadataStr)) {
+            throw JSONRPCError(RPC_TYPE_ERROR, "Invalid metadata: must be hex string");
+        }
+    }      
+
     EnsureWalletIsUnlocked();
 
     CWalletTx wtx;
     vector<CWalletTx> wtxs = SendAnyMoney(address.Get(), nAmount, confidentiality_pubkey,
-        wtx, fIgnoreBlindFail, fSplitTransactions, fSortingType);
+        wtx, fIgnoreBlindFail, fSplitTransactions, fSortingType, metadataStr);
 
     std::string blinds;
     UniValue arr(UniValue::VARR);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2778,7 +2778,7 @@ std::vector<CWalletTx> CWallet::CreateTransaction(vector<CRecipient>& vecSend, C
     std::string& strFailReason, const CCoinControl* coinControl, bool sign, std::vector<CAmount> *outAmounts,
     bool fBlindIssuances, const uint256* issuanceEntropy, const CAsset* reissuanceAsset,
     const CAsset* reissuanceToken, CAsset feeAsset, bool fIgnoreBlindFail, bool fSplitTransactions,
-    std::vector<COutput> vInputPool, bool fFindFeeAsset, std::map<CAsset, std::vector<COutput>>* mAvailableInputs)
+    std::vector<COutput> vInputPool, bool fFindFeeAsset, std::map<CAsset, std::vector<COutput>>* mAvailableInputs, std::string metadataStr)
 {
     // original unchanged recipient vector
     const vector<CRecipient> vecSendOriginal = vecSend;
@@ -3550,6 +3550,16 @@ std::vector<CWalletTx> CWallet::CreateTransaction(vector<CRecipient>& vecSend, C
             scriptPubKey << std::vector<unsigned char>(contract.begin(), contract.end());
             CTxOut txoutcontract(feeAsset,0,scriptPubKey);
             txNew.vout.push_back(txoutcontract);
+        }
+
+        //add metadata as OP_RETURN if present
+        if (!metadataStr.empty()) {
+            std::vector<unsigned char> scriptData = ParseHex(metadataStr);
+            CScript scriptPubKey;
+            scriptPubKey << OP_RETURN;
+            scriptPubKey << scriptData;
+            CTxOut metadata(feeAsset,0,scriptPubKey);
+            txNew.vout.push_back(metadata);
         }
 
         // TODO Do actual blinding/caching here to allow for amount adjustments until end

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -910,7 +910,7 @@ public:
                            std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true, std::vector<CAmount> *outAmounts = NULL,
                            bool fBlindIssuances = true, const uint256* issuanceEntropy = NULL, const CAsset* reissuanceAsset = NULL, const CAsset* reissuanceToken = NULL,
                            CAsset feeAsset = CAsset(), bool fIgnoreBlindFail = true, bool fSplitTransactions = false, std::vector<COutput> vInputPool = std::vector<COutput>(),
-                           bool fFindFeeAsset = false, std::map<CAsset, std::vector<COutput>>* mAvailableInputs = new std::map<CAsset, std::vector<COutput>>());
+                           bool fFindFeeAsset = false, std::map<CAsset, std::vector<COutput>>* mAvailableInputs = new std::map<CAsset, std::vector<COutput>>(), std::string metadataStr = "");
     bool CommitTransaction(CWalletTx& wtxNew, std::vector<CReserveKey>& reservekey, CConnman* connman, CValidationState& state);
 
     bool DistributeFeeToNewBalance(CAmountMap& mapValue, CAsset feeAsset, std::vector<CRecipient>& vecSend,


### PR DESCRIPTION
Option (via additional argument) to add OP_RETURN metadata to a transaction generated by the sendanytoaddress RPC. 