### PR TITLE
Increase spam tolerance

### DIFF
--- a/qa/rpc-tests/sendany.py
+++ b/qa/rpc-tests/sendany.py
@@ -196,5 +196,23 @@ class SendAnyTest (BitcoinTestFramework):
             if outpt["scriptPubKey"]["hex"] == '6a20' + metadata: or_md = True
         assert(or_md)
 
+        # test createanytoaddress metadata tag
+        metadata = 'ec45a16ce1a3eb5784df3dfa196aad6bd57f6c2f6969e97d1eb5402ccd39d628'
+        tx = self.nodes[0].createanytoaddress(addr1, 0.5, True, False,1,False,metadata)
+        txs= self.nodes[0].signrawtransaction(tx[0])
+        txid= self.nodes[0].sendrawtransaction(txs['hex'])
+        print(txs['hex'])
+        assert(txid in self.nodes[0].getrawmempool())
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        tx = self.nodes[0].getrawtransaction(txid,True)
+        or_md = False
+        for outpt in tx["vout"]:
+            print(outpt)
+            if outpt["scriptPubKey"]["hex"] == '6a20' + metadata: or_md = True
+        assert(or_md)
+
 if __name__ == '__main__':
     SendAnyTest().main()
+B

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -119,7 +119,7 @@ bool IsSpam(const CTransaction &tx) {
     int num_op_return = 0;
     for (CTxOut const &txout : tx.vout) {
         if (!Solver(txout.scriptPubKey, whichType, vSolutions) || whichType == TX_NULL_DATA) num_op_return++;
-        if (num_op_return > 1) return true;
+        if (num_op_return > 2) return true;
       if (whichType == TX_PUBKEYHASH || whichType == TX_SCRIPTHASH) {
           tuple<uint160, CAsset> aa_pair(uint160(vSolutions[0]), txout.nAsset.GetAsset());
           if (find(addr_asset.begin(), addr_asset.end(), aa_pair) != addr_asset.end()) return true;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -173,6 +173,10 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "testproposedblock", 1, "acceptnonstd" },
     { "sendtomainchain", 2, "subtractfeefromamount"},
     { "getnewblockhex", 0, "required_age"},
+    { "sendanytoaddress", 1, "amount"},
+    { "sendanytoaddress", 4, "ignoreblindfail"}  ,
+    { "sendanytoaddress", 5, "splitlargetxs"}  ,
+    { "sendanytoaddress", 6, "balancesorttype"}  ,    
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },


### PR DESCRIPTION
Allow one extra OP_RETURN output in transactions in order to accommodate the sendanytoaddress RPC metadata.